### PR TITLE
feat: add Containerfile and DESCRIPTION

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -1,0 +1,45 @@
+name: Build Docker image for OMA manuscript
+env:
+  REPOSITORY_OWNER: ${{ github.repository_owner }}
+  DOCKER_IMAGE_NAME: oma-manuscript
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN}}
+
+      - name: Extract metadata for Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.actor }}/oma-manuscript
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,11 @@
+FROM docker.io/bioconductor/bioconductor_docker:RELEASE_3_22-R-4.5.2
+
+WORKDIR /project
+COPY DESCRIPTION DESCRIPTION
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y libcurl4-openssl-dev pandoc && \
+    quarto install tinytex && \
+    R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org'))" && \
+    R -e "remotes::install_deps(dependencies = TRUE)"
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,82 @@
+Package: OMA_manuscript
+Type: Package
+Version: 0.0.1
+Authors@R:
+    c(person(given = "Tuomas", family = "Borman", role = c("aut", "cre"),
+             email = "tuomas.v.borman@utu.fi",
+             comment = c(ORCID = "0000-0002-8563-8884")),
+      person(given = "Giulio", family = "Benedetti", role = c("aut"),
+             comment = c(ORCID = "0000-0002-8732-7692")),
+      person(given = "Geraldson", family = "Muluh", role = c("aut"),
+             comment = c(ORCID = "0000-0002-9721-5192")),
+      person(given = "Aura", family = "Raulo", role = c("aut"),
+             comment = c(ORCID = "0000-0003-4860-7840")),
+      person(given = "Benjamin", family = "Valderrama", role = c("aut"),
+             comment = c(ORCID = "0000-0002-4740-8965")),
+      person(given = "Artur", family = "Sannikov", role = c("aut"),
+             comment = c(ORCID = "0000-0001-7765-123X")),
+      person(given = "Stefanie", family = "Peschel", role = c("aut"),
+             comment = c(ORCID = "0000-0002-7936-7627")),
+      person(given = "Yihan", family = "Liu", role = c("aut"),
+             comment = c(ORCID = "0009-0008-0462-7501")),
+      person(given = "Rasmus", family = "Hindström", role = c("aut"),
+             comment = c(ORCID = "0009-0004-5731-178X")),
+      person(given = "Katariina", family = "Pärnänen", role = c("aut"),
+             comment = c(ORCID = "0000-0003-2220-1738")),
+      person(given = "Christian L.", family = "Müller", role = c("aut"),
+             comment = c(ORCID = "0000-0002-3821-7083")),
+      person(given = "Aki S.", family = "Havulinna", role = c("aut"),
+             comment = c(ORCID = "0000-0002-4787-8959")),
+      person(given = "Sudarshan", family = "Shetty", role = c("aut"),
+             comment = c(ORCID = "0000-0001-7280-9915")),
+      person(given = "Marcel", family = "Ramos", role = c("aut"),
+             comment = c(ORCID = "0000-0002-3242-0582")),
+      person(given = "Domenick J.", family = "Braccia", role = c("aut"),
+             comment = c(ORCID = "0000-0002-4606-6254")),
+      person(given = "Héctor Corrada", family = "Bravo", role = c("aut"),
+             comment = c(ORCID = "0000-0002-1255-4444")),
+      person(given = "Felix M.", family = "Ernst", role = c("aut"),
+             comment = c(ORCID = "0000-0001-5064-0928")),
+      person(given = "Levi", family = "Waldron", role = c("aut"),
+             comment = c(ORCID = "0000-0003-2725-0694")),
+      person(given = "Thomaz F. S.", family = "Bastiaanssen", role = c("aut"),
+             comment = c(ORCID = "0000-0001-6891-734X")),
+      person(given = "Himel", family = "Mallick", role = c("aut"),
+             comment = c(ORCID = "0000-0003-4956-2429")),
+      person(given = "Leo", family = "Lahti", role = c("aut"),
+             comment = c(ORCID = "0000-0001-5537-637X"))
+    )
+biocViews: Microbiome, Software, DataImport
+License: Artistic-2.0 | file LICENSE
+Encoding: UTF-8
+LazyData: false
+Depends:
+    R (>= 4.0)
+Imports:
+    bench,
+    BiocPkgTools,
+    DelayedArray,
+    dplyr,
+    ggh4x,
+    lubridate,
+    maaslin3,
+    mia,
+    miaTime,
+    miaViz,
+    microbiome,
+    microbiomeDataSets,
+    patchwork,
+    philr,
+    picante,
+    scater,
+    see,
+    speedyseq,
+    tidyverse
+Suggests:
+    knitr
+Remotes:
+    microbiome/miaTime@39abd1c95db45f6f944decce20f518d15d5e79cb,
+    mikemc/speedyseq@0057652ff7a4244ccef2b786dca58d901ec2fc62
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.2
+VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Authors@R:
              comment = c(ORCID = "0009-0008-0462-7501")),
       person(given = "Rasmus", family = "Hindström", role = c("aut"),
              comment = c(ORCID = "0009-0004-5731-178X")),
+      person("OMA consortium", role = c("aut")),
       person(given = "Katariina", family = "Pärnänen", role = c("aut"),
              comment = c(ORCID = "0000-0003-2220-1738")),
       person(given = "Christian L.", family = "Müller", role = c("aut"),


### PR DESCRIPTION
See #68.

The PR introduces Container file to build OCI-compliant container images using the DESCRIPTION file.

## TODO:

- [x] I could not make `quarto install tinytex` to install when building locally. For some reason, it cannot download the tinytex from remote, even though from inside the container it works
- [x] GitHub Actions should be used to build the image and push it to ghcr.io
