### PR TITLE
Reorganise sections on "data infrastructure" and "alternative frameworks"

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -877,17 +877,6 @@
   publisher     = {American Society for Microbiology},
   abstract      = {We introduce a novel compositional beta diversity metric, robust Aitchison PCA, which integrates centered log-ratio transformation with matrix completion to improve microbiome data analysis. This technique enhances ordination, clustering, and interpretability of sparse high-dimensional sequencing data while preserving biological signals, outperforming standard methods in simulation and case studies.}
 }
-@article{martino2025,
-  author        = {},
-  title         = {{Joint-RPCA}: Domain-Aware Multi-Omics Integration for Systems Microbiology},
-  journal       = {},
-  volume        = {},
-  number        = {},
-  pages         = {},
-  note          = {in press},
-  year          = {2025},
-  doi           = {}
-}
 @article{mcdonald2012,
   author        = {McDonald, Daniel and Clemente, Jose C and Kuczynski, Justin and Rideout, Jai Ram and Stombaugh, Jesse and Wendel, Doug and Wilke, Andreas and Huse, Susan and Hufnagle, John and Meyer, Folker and Knight, Rob and Caporaso, J Gregory},
   title         = {The Biological Observation Matrix {(BIOM)} format or: how I learned to stop worrying and love the ome-ome},

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -165,6 +165,16 @@
   issn          = {2635-0041},
   abstract      = {Hierarchical data structures are prevalent across several research fields, as they represent an organized and efficient approach to study complex interconnected systems. Their significance is particularly evident in microbiome analysis, where microbial communities are classified at various taxonomic levels using phylogenetic trees. In light of this trend, the R/Bioconductor community has established a reproducible analytical framework for hierarchical data, which relies on the generic and optimized TreeSummarizedExperiment data container. However, this framework requires basic programming skills. To reduce the entry requirements, we developed iSEEtree, an R package, which provides a visual interface for the analysis and exploration of TreeSummarizedExperiment objects, thereby expanding the interactive graphics capabilities of related work to hierarchical structures. This way, users can interactively explore several aspects of their data without the need for an extensive knowledge of R programming. We describe how iSEEtree enables the exploration of hierarchical multi-table data and demonstrate its functionality with applications to microbiome analysis. iSEEtree was implemented in the R programming language and is available on Bioconductor at https://bioconductor.org/packages/iSEEtree under an Artistic 2.0 license.}
 }
+@misc{benedetti2026,
+  author       = {Giulio Benedetti and Leo Lahti and Eetu Tammi and Muluh and Tuomas Borman},
+  title        = {{miaData}},
+  month        = {jul},
+  year         = {2026},
+  publisher    = {Zenodo},
+  version      = {v1.0.0},
+  doi          = {10.5281/zenodo.21198374},
+  url          = {https://doi.org/10.5281/zenodo.21198374}
+}
 @article{berg2020,
   author        = {Gabriele Berg and Daria Rybakova and Doreen Fischer and Tomislav Cernava and Marie-Christine Champomier Verg\`{e}s and Trevor Charles and Xiaoyulong Chen and Luca Cocolin and Kellye Eversole and Gema Herrero Corral and Maria Kazou and Linda Kinkel and Lene Lange and Nelson Lima and Alexander Loy and James A. Macklin and Emmanuelle Maguin and Tim Mauchline and Ryan McClure and Birgit Mitter and Matthew Ryan and Inga Sarand and Hauke Smidt and Bettina Schelkle and Hugo Roume and G. Seghal Kiran and Joseph Selvin and Rafael Soares Correa de Souza and Leo van Overbeek and Brajesh K. Singh and Michael Wagner and Aaron Walsh and Angela Sessitsch and Michael Schloter},
   title         = {Microbiome definition re-visited: old concepts and new challenges},
@@ -222,7 +232,7 @@
   volume        = {13},
   number        = {7},
   pages         = {581--583},
-  month         = jul,
+  month         = {jul},
   year          = {2016},
   issn          = {1548-7105},
   doi           = {10.1038/nmeth.3869}
@@ -268,7 +278,7 @@
   publisher     = {Institute of Mathematical Statistics},
   author        = {Chambers,  John M.},
   year          = {2014},
-  month         = may
+  month         = {may}
 }
 @article{cheng2019,
   title         = {An additive Gaussian process regression model for interpretable non-parametric analysis of longitudinal data},
@@ -309,7 +319,7 @@
   title         = {{Advancing microbiome research with machine learning: key findings from the ML4Microbiome {COST} action}},
   journal       = {Frontiers in Microbiology},
   year          = {2023},
-  month         = 09,
+  month         = {Sep},
   volume        = {14},
   issn          = {1664-302X},
   doi           = {10.3389/fmicb.2023.1257002},
@@ -397,7 +407,7 @@
   doi           = {10.1101/2025.02.13.638109},
   publisher     = {Cold Spring Harbor Laboratory},
   abstract      = {Previous benchmarking of differential abundance (DA) analysis methods in microbiome studies have employed synthetic data, simulations, and {\textquotedblleft}real data{\textquotedblright} examples, but to the best of our knowledge, none have yet employed experimental data with known {\textquotedblleft}ground truth{\textquotedblright} differential abundance. A key debate in the field centers on whether compositional methods are necessary for DA analysis, which is challenging to answer due to the lack of ground truth data. To address this gap, we created the Bioconductor data package MicrobiomeBenchmarkData, featuring three microbiome datasets with established biological ground truths: 1) diverse oral microbiomes from supragingival and subgingival plaques, expected to favor aerobic and anaerobic bacteria, respectively, 2) low-diversity microbiomes from healthy vaginas and bacterial vaginosis, conditions that have been well-characterized through cell culture and microscopy, and 3) a spike-in dataset with constant, known absolute abundances of three bacteria. We benchmarked 17 DA approaches and demonstrated that compositional DA methods are not beneficial but rather lack sensitivity, show increased variability in constant-abundance spike-ins, and, most surprisingly, more frequently produce paradoxical results with DA in the wrong direction for the low-diversity microbiome. Conversely, commonly used methods in microbiome literature, such as LEfSe, the Wilcoxon test, and RNA-seq-derived methods, performed best. We conclude that researchers continue using widely adopted non-parametric or RNA-seq DA methods and that further development of compositional methods includes benchmarking against datasets with known biological ground truth.Competing Interest StatementThe authors have declared no competing interest.},
-  url           = {https://www.biorxiv.org/content/early/2025/02/17/2025.02.13.638109},
+  url           = {https://doi.org/10.1101/2025.02.13.638109},
   eprint        = {https://www.biorxiv.org/content/early/2025/02/17/2025.02.13.638109.full.pdf},
   journal       = {bioRxiv}
 }
@@ -499,7 +509,8 @@
   number        = {6551},
   pages         = {181--186},
   year          = {2021},
-  publisher     = {American Association for the Advancement of Science}
+  publisher     = {American Association for the Advancement of Science},
+  doi           = {10.1126/science.aba5483}
 }
 @article{gupta2019,
   author        = {Gupta, Shashank and Mortensen, Martin S. and Schj{\o}rring, Susanne and Trivedi, Urvish and Vestergaard, Gisle and Stokholm, Jakob and Bisgaard, Hans and Krogfelt, Karen A. and S{\o}rensen, S{\o}ren J.},
@@ -699,6 +710,17 @@
   doi           = {10.1038/s41598-020-78511-y},
   issn          = {2045-2322},
   abstract      = {The commensal microbiome is known to influence a variety of host phenotypes. Microbiome profiling followed by differential abundance analysis has been established as an effective approach to study the mechanisms of host-microbiome interactions. However, it is challenging to interpret the collective functions of the resultant microbe-sets due to the lack of well-organized functional characterization of commensal microbiome. We developed microbe-set enrichment analysis (MSEA) to enable the functional interpretation of microbe-sets by examining the statistical significance of their overlaps with annotated groups of microbes that share common attributes such as biological function or phylogenetic similarity. We then constructed microbe-set libraries by query PubMed to find microbe-mammalian gene associations and disease associations by parsing the Disbiome database. To demonstrate the utility of our novel MSEA methodology, we carried out three case studies using publicly available curated knowledge resource and microbiome profiling datasets focusing on human diseases. We found MSEA not only yields consistent findings with the original studies, but also recovers insights about disease mechanisms that are supported by the literature. Overall, MSEA is a useful knowledge-based computational approach to interpret the functions of microbes, which can be integrated with microbiome profiling pipelines to help reveal the underlying mechanism of host-microbiome interactions.}
+}
+@article{kuhn2026,
+  title         = {Metalog: curated and harmonised contextual data for global metagenomics samples},
+  author        = {Kuhn, Michael and Schmidt, Thomas Sebastian B and Ferretti, Pamela and G{\l}azek, Anna and Robbani, Shahriyar Mahdi and Akanni, Wasiu and Fullam, Anthony and Schudoma, Christian and Cetin, Ela and Hassan, Mariam and others},
+  journal       = {Nucleic Acids Research},
+  volume        = {54},
+  number        = {D1},
+  pages         = {D826--D834},
+  year          = {2026},
+  doi           = {10.1093/nar/gkaf1118},
+  publisher     = {Oxford University Press}
 }
 @article{kullberg2024,
   author        = {Kullberg, Robert F. J. and Wikki, Irina and Haak, Bastiaan W. and Kauko, Anni and Galenkamp, Henrike and Peters-Sengers, Hessel and Butler, Joe M. and Havulinna, Aki S. and Palmu, Joonatan and McDonald, Daniel and Benchraka, Chouaib and Abdel-Aziz, Mahmoud I. and Prins, Maria and Maitland van der Zee, Anke H. and van den Born, Bert-Jan and Jousilahti, Pekka and de Vos, Willem M. and Salomaa, Veikko and Knight, Rob and Lahti, Leo and Nieuwdorp, Max and Niiranen, Teemu and Wiersinga, W. Joost},

--- a/manuscript.qmd
+++ b/manuscript.qmd
@@ -357,7 +357,7 @@ R/Bioconductor ecosystem.
 
 Several data analytical frameworks are available for microbiome data science,
 each distinguished by its underlying paradigms, user communities, and scope.
-For example, tools such as QIIME2 [@bolyen2019], Anvi'o
+For example, tools such as QIIME 2 [@bolyen2019], Anvi'o
 [@eren2021], and Mothur [@schloss2009] emphasize standardized, modular
 approaches tailored to microbiome analysis. These frameworks provide
 validated and user-friendly solutions, enabling development of efficient
@@ -1009,7 +1009,7 @@ data from common tabular data types, certain non-standard file formats may
 require additional data wrangling. To streamline data
 import, we provide importers for a variety of standard microbiome file
 formats including BIOM [@mcdonald2012], MetaPhlAn/HUMAnN (MetaPhlAn
-v. 2&ndash;4, HUMAnN v. 3) [@mciver2017], Mothur [@schloss2009], QIIME2
+v. 2&ndash;4, HUMAnN v. 3) [@mciver2017], Mothur [@schloss2009], QIIME 2
 [@bolyen2019] and the TAXonomic Profile Aggregation and
 standardization format (taxpasta) [@beber2023]. These importers bridge the gap
 between the raw sequence processing and downstream statistical analysis in R,
@@ -1300,7 +1300,7 @@ association-based approaches are often easier to interpret, they do not
 explicitly account for the fact that microbes operate within complex
 communities. In contrast, latent variable methods such
 as multi-omics factor analysis [@argelaguet2020],
-joint robust PCA [@martino2025] and multiblock partial least
+joint robust PCA [@martino2019] and multiblock partial least
 squares discriminant analysis [@singh2019] model shared latent
 structure across modalities, enabling the discovery and visualization of
 coordinated variation at the community level.

--- a/manuscript.qmd
+++ b/manuscript.qmd
@@ -623,10 +623,10 @@ and overall interoperability.
 : Key elements of the Bioconductor data containers for microbiome analysis.
 {#tbl-elements tbl-colwidths="[18,62,3,9,8]"}
 
-$^a$ While MAE does not contain conventional slots (with the exception
+$^a$While MAE does not contain conventional slots (with the exception
 of colData), its experiments can include any number of data containers that
-provide those slots. $^b$ altExp samples must match assay samples in a 1-to-1
-mapping. $^c$ The sampleMap supports diverse mappings between samples from
+provide those slots. $^b$altExp samples must match assay samples in a 1-to-1
+mapping. $^c$The sampleMap supports diverse mappings between samples from
 different experiments (1-to-1, 1-to-many, many-to-1 and many-to-many). SE,
 SummarizedExperiment; TreeSE, TreeSummarizedExperiment; MAE, MultiAssayExperiment.
 
@@ -642,18 +642,22 @@ encompass taxonomic and functional profiles from thousands of
 published microbiome studies and tens of thousands samples that can
 be accessed with the available tools for research and educational purposes.
 
-| Data resource                               | Package                                                                  | # studies or datasets | # samples |
-|---------------------------------------------|--------------------------------------------------------------------------|-----------------------|-----------|
-| Curated metagenomic data [@pasolli2017]     | curatedMetagenomicData [@pasolli2017]                                    | 93                    | 22,588    |
-| HoloFood [@rogers2024]                      | HoloFoodR [@holofoodr]                                                   | -                     | 9,990     |
-| MGnify [@gurbich2023]                       | MGnifyR [@mgnifyr]                                                       | 5,129                 | 629,821   |
-| microbiomeDataSets [@microbiomedatasets]    | microbiomeDataSets [@microbiomedatasets]                                 | 6                     | 19,100    |
-| Microbiome Benchmark Data [@gamboa-tuz2025] | MicrobiomeBenchmarkData [@gamboa-tuz2025]                                | 6                     | 1,125     |
-| Human Microbiome Project 2 [@hmp2data]      | HMP2data [@hmp2data]                                                     | 3                     | 11,493    |
-| A compilation of open microbiome datasets   | [https://github.com/microbiome/data](https://github.com/microbiome/data) | 8                     | 18,777    |
+| Data resource           | References                | # Studies  | # Samples |
+|-------------------------|:-------------------------:|-----------:|----------:|
+| MGnifyR                 | [@gurbich2023; @mgnifyr]  | 5,616      | 429,108   |
+| Metalog                 | [@kuhn2026]               | 1,074      | 157,483   |
+| curatedMetagenomicData  | [@pasolli2017]            | 93         | 22,588    |
+| miaData                 | [@benedetti2026]          | 9          | 20,404    |
+| microbiomeDataSets      | [@microbiomedatasets]     | 6          | 19,100    |
+| HMP2data                | [@hmp2data]               | 3          | 11,493    |
+| HoloFoodR$^a$           | [@rogers2024; @holofoodr] | 9          | 9,990     |
+| MicrobiomeBenchmarkData | [@gamboa-tuz2025]         | 6          | 1,125     |
 
-: Auxiliary open microbiome data resources (last accessed on 29/09/2025).
-{#tbl-dataresources tbl-colwidths="[30,40,15,15]"}
+: Open microbiome data resources (last accessed on 05/07/2026).
+{#tbl-dataresources tbl-colwidths="[40,20,20,20]"}
+
+$^a$HoloFood microbiome datasets are deposited in the MGnify database.
+HMP, Human Microbiome Project.
 
 # Data preparation {#sec-process}
 
@@ -998,7 +1002,7 @@ data containers and shared methodological approaches in related research fields
 can significantly expand the transfer of existing toolkits to adjacent or emerging
 disciplines. Importantly, this framework enables integration not only within the Bioconductor ecosystem
 but also with external pipelines, including bioBakery [@navarro2024; @mciver2017], and foreign platforms through language-specific interfaces,
-namely `Rcpp` for C+, `reticulate` for Python, and `JuliaCall` for Julia.
+namely Rcpp for C++, reticulate for Python, and JuliaCall for Julia.
 These connections allow users to combine the
 most suitable tools across multiple frameworks, while ensuring
 cross-language interoperability of structured data through standard containers such as TreeSE and MAE.
@@ -1506,7 +1510,7 @@ benchmark_df <- benchmark_out |>
         (object == "pseq" & N <= beta_threshold[[1]]) |
         (object == "tse" & N <= beta_threshold[[2]]))
 
-# Summarise benchmarking results with mean time and standard deviation
+# Summarize benchmarking results with mean time and standard deviation
 benchmark_df <- benchmark_df |>
     group_by(method, object, N) |>
     summarise(
@@ -1589,7 +1593,7 @@ scientific_10 <- function(y) {
 }
 breaks <- benchmark_df[["N"]][log10(benchmark_df[["N"]]) %% 1 == 0] |> unique()
 
-# Visualise benchmarking results: time
+# Visualize benchmarking results: time
 p1 <- ggplot(benchmark_df, aes(x = N, y = Time, colour = object)) +
     geom_errorbar(aes(ymin = Time - TimeSE, ymax = Time + TimeSE), width = 0) +
     geom_line() +
@@ -1612,7 +1616,7 @@ p1 <- ggplot(benchmark_df, aes(x = N, y = Time, colour = object)) +
         strip.text = element_text(size = 12),
         strip.background = element_blank()
     )
-# Visualise benchmarking results: memory
+# Visualize benchmarking results: memory
 p2 <- ggplot(benchmark_df, aes(x = N, y = Memory / 1e6, colour = object)) +
     geom_line() +
     geom_point() +
@@ -1716,8 +1720,6 @@ we have introduced a comprehensive, interoperable ecosystem
 developed as an extensive community effort. We also provide exhaustive guidance in
 the OMA book, thereby supporting independent learning and reproducible analysis in
 microbiome research and beyond.
-
-
 
 **The Bioconductor community** is widely recognized for
 developing open research software for life sciences. Its

--- a/manuscript.qmd
+++ b/manuscript.qmd
@@ -1807,6 +1807,10 @@ LL and TB initiated and coordinated the work. All authors contributed
 material, participated in manuscript preparation, and approved the final
 version.
 
+## Competing interests {#sec-interests}
+
+The authors declare no competing interests.
+
 ## Acknowledgments {#sec-acknowledgments}
 
 This project received funding from the European Union’s Horizon 2020

--- a/manuscript.qmd
+++ b/manuscript.qmd
@@ -353,43 +353,6 @@ Microbiome Analysis with Bioconductor_ (OMA), which represents a comprehensive
 compilation of best practices and current trends in microbiome data science using the
 R/Bioconductor ecosystem.
 
-# Data analytical frameworks {#sec-data_frameworks}
-
-Several data analytical frameworks are available for microbiome data science,
-each distinguished by its underlying paradigms, user communities, and scope.
-For example, tools such as QIIME 2 [@bolyen2019], Anvi'o
-[@eren2021], and Mothur [@schloss2009] emphasize standardized, modular
-approaches tailored to microbiome analysis. These frameworks provide
-validated and user-friendly solutions, enabling development of efficient
-end-to-end workflows for microbiome research. However, they are typically
-designed around specific data types, which limits flexibility
-when integrating heterogeneous data modalities within a unified analytical
-framework. In contrast, Bioconductor embraces a more exploratory, statistically
-oriented paradigm spanning multiple areas of bioinformatics beyond
-microbiome research.
-
-This data analytical paradigm of Bioconductor is similar to scikit-bio's
-[@aton2025]. While scikit-bio as a Python-based ecosystem benefits from rapidly
-evolving machine learning and artificial intelligence tools, Bioconductor’s
-strengths lie in its vast statistical ecosystem dedicated to omics research and
-strong interoperability with other computational environments.
-Another key distinction is community structure: scikit-bio is more
-centralized, whereas Bioconductor packages are developed and maintained by an
-open community, resulting in a broad toolkit and collaboration enabling easy
-reuse of common solutions.
-Although this approach can introduce some challenges, such as dependency management,
-package compatibility, and differences in package stability, these are actively
-addressed through several coordinated mechanisms. First, submitted packages undergo
-peer review, ensuring relevance and adherence to standards such as documentation
-and working examples. Secondly, Bioconductor follows synchronized, semiannual
-release cycle, during which packages are frozen and mutually compatible. Thirdly,
-all packages are continuously tested within Bioconductor's automated build system,
-which ensures that breaking changes are rapidly detected before release. Each package has an active
-maintainer who is notified of failures and resolves them in a timely manner.
-Finally, community guidelines and continuous integration practices, together
-with shared data structures such as (Tree)SummarizedExperiment, further improve
-interoperability between packages.
-
 # Data infrastructure {#sec-infra}
 
 Data scientists routinely deal with interlinked assays, hierarchical data
@@ -557,7 +520,7 @@ While maintaining interoperability with
 the broader Bioconductor ecosystem, the TreeSummarizedExperiment
 (TreeSE) class [@huang2021] extends the SE and SCE data structures to
 hierarchical datasets by incorporating both feature and sample organizations
-as tree structures (@fig-datacontainers a). Moreover, TreeSE supports the
+as tree structures (@fig-datacontainers a and @tbl-elements). Moreover, TreeSE supports the
 storage of other common elements of microbiome data, for example, reference
 sequences, and incorporates results from common analytical procedures such as
 dimensionality reduction, statistical transformations, and agglomeration by
@@ -565,15 +528,821 @@ taxonomic, functional or other information. The interoperability with other
 Bioconductor classes facilitates scalable analysis and the design of modular
 yet flexible workflows, as TreeSE inherits full compatibility with methods
 designed for SE and SCE. In particular, the direct interoperability with the
-widely adopted SE data science ecosystem distinguishes our TreeSE
+widely adopted SE data science ecosystem distinguishes the (Tree)SE
 framework from phyloseq, which is another popular Bioconductor data container
-developed initially with a focus on 16S amplicon data analysis [@mcmurdie2012].
-TreeSE provides a more general framework than phyloseq, as the former not only
+initially developed with a focus on 16S amplicon data analysis [@mcmurdie2012].
+In contrast, TreeSE provides a more general framework, as it not only
 accommodates the typical components of a phyloseq object
 (taxa abundances, sample metadata, phylogenetic tree, and reference sequences),
 but also extends to multi-modal datasets encompassing
 parallel taxonomic levels, functional predictions, and resistome, metabolome or
-other profiles and alternative feature representations. It also offers
+other profiles and alternative feature representations.
+
+| Data container                                | Target use                                                  |
+|-----------------------------------------------|-------------------------------------------------------------|
+| SummarizedExperiment (SE)[@huber2015]         | generic container linking multiple data tables (assays)     |
+| TreeSummarizedExperiment (TreeSE)[@huang2021] | extension incorporating hierarchical data structures        |
+| MultiAssayExperiment (MAE)[@ramos2017]        | binding omic-specific containers in multi-omics experiments |
+
+: Bioconductor integrative data containers for microbiome analysis.
+{#tbl-containers tbl-colwidths="[50,50]"}
+
+![**Bioconductor data containers for microbiome data.** **(a)
+TreeSummarizedExperiment (TreeSE)** supports hierarchical, multi-table
+microbiome analysis. A data object can accommodate: i) _assays_ that describe
+the abundances of features in each sample (*e.g.* taxonomic units, resistance
+genes, or predicted functions), ii) _colData_ with tabular metadata on each
+sample, iii) _rowData_ with tabular metadata on each feature (*e.g.* taxonomic
+mappings), and iv) tree information describing feature hierarchies, such as
+phylogenetic relations between the taxonomic units (rowTree) or host species
+(colTree). TreeSE can thus link multiple numeric abundance tables and their
+derived versions (*e.g.* statistical transformations, different taxonomic
+levels, dimensionality reduction) with tabular and hierarchical side
+information on the features (rows) and samples (columns). Additional slots for
+reference sequences and experiment metadata are available. Adapted from
+[@huang2021]. **(b) MultiAssayExperiment (MAE)** facilitates the integration of
+interlinked datasets that may represent different omics modalities
+linked by potentially non-trivial sample mappings. Adapted from
+[@ramos2017].](figures/data_containers.png){#fig-datacontainers}
+
+**Multi-assay data structures.** Contemporary microbiome research frequently
+involves data across multiple measurement modalities for enhanced functional
+and mechanistic insights. This brings the need to find an appropriate
+representation for each data type and map the links between them. Whereas the
+TreeSE data container is broadly applicable to different modalities such as
+taxonomic, resistome, transcriptome, proteome, and metabolome profiling data,
+dedicated data containers have been developed for certain modalities by the
+Bioconductor community to address their specific characteristics; examples
+include single cell sequencing [@amezquita2020] and host genomics
+[@lawrence2013]. Linking data across modalities presents an additional technical
+challenge, as multi-omics datasets are often sparse and only a subset of the
+samples may be shared across multiple modalities [@sherwani2025]. In other
+cases, a single sample in one modality may link to several samples in
+another modality [@husso2023] (*e.g.*, due to technical or spatial replication).
+These scenarios require the ability to integrate multiple
+data modalities into a single object and create flexible sample mappings across them.
+The MultiAssayExperiment (MAE) data container [@ramos2017] addresses these
+challenges by introducing a formal mapping layer (sampleMap) that links
+biological samples to their corresponding measurements in each modality
+(@fig-datacontainers b and @tbl-elements). This design supports one-to-one, one-to-many, and
+partially overlapping sample relationships across experiments. Importantly, this
+mapping is also accessible for downstream operations. For instance, when
+subsetting a MAE object
+(*e.g.*, selecting samples with both microbiome and metabolome data), the
+framework automatically resolves the intersection of available samples and
+ensures consistent alignment across all modalities. Such structured handling of
+sample relationships is particularly important for integrative methods, as it
+reduces the risk of sample mismatches, a common source of irreproducibility in
+ad hoc multi-table analyses. For instance, diagonal integration methods
+[@xu2022; @argelaguet2021computational]&mdash;where shared features across
+data types may not be explicitly defined&mdash;can benefit from
+such a systematic framework that enforces anchor alignment. This reflects lessons
+learned from single-cell data integration, where shared anchors and hierarchical
+mapping have proven essential for interpretability. To summarize, flexible mapping of samples
+across several data objects is key for efficient data integration, method sharing,
+and overall interoperability.
+
+| Slot          | Content                                      | SE | TreeSE | MAE$^a$ |
+|---------------|----------------------------------------------|:--:|:------:|:-------:|
+| **Tables**    |                                              |    |        |         |
+| assays        | tables of features (rows) and samples (cols) | X  | X      | X       |
+| altExps$^b$   | experiments with variable number of features |    | X      | X       |
+| reducedDims   | results of dimensionality reduction          |    | X      | X       |
+| **Rows**      |                                              |    |        |         |
+| rowData       | side information on features                 | X  | X      | X       |
+| rowPairs      | linkage between pairs of associated features |    | X      | X       |
+| rowTrees      | hierarchical organization of features        |    | X      | X       |
+| referenceSeq  | reference sequences of features              |    | X      | X       |
+| **Columns**   |                                              |    |        |         |
+| colData       | side information on samples                  | X  | X      | X       |
+| colTrees      | hierarchical organization of samples         |    | X      | X       |
+| sampleMap$^c$ | flexible sample mapping across experiments   |    |        | X       |
+| **Other**     |                                              |    |        |         |
+| metadata      | additional information on the experiment     | X  | X      | X       |
+
+: Key elements of the Bioconductor data containers for microbiome analysis.
+{#tbl-elements tbl-colwidths="[18,62,3,9,8]"}
+
+$^a$ While MAE does not contain conventional slots (with the exception
+of colData), its experiments can include any number of data containers that
+provide those slots. $^b$ altExp samples must match assay samples in a 1-to-1
+mapping. $^c$ The sampleMap supports diverse mappings between samples from
+different experiments (1-to-1, 1-to-many, many-to-1 and many-to-many). SE,
+SummarizedExperiment; TreeSE, TreeSummarizedExperiment; MAE, MultiAssayExperiment.
+
+**Data resources.** Several open microbiome data resources are supported,
+enabling direct data import into the aforementioned data containers for further
+downstream analysis within the Bioconductor methods ecosystem
+(@tbl-dataresources). Examples of the available data resources include
+curatedMetagenomicData [@pasolli2017], HoloFood [@rogers2024],
+microbiomeDataSets [@microbiomedatasets], and the EBI/MGnify database
+[@gurbich2023]. In addition, Bioconductor packages often
+include built-in demonstration datasets. Collectively, these resources
+encompass taxonomic and functional profiles from thousands of
+published microbiome studies and tens of thousands samples that can
+be accessed with the available tools for research and educational purposes.
+
+| Data resource                               | Package                                                                  | # studies or datasets | # samples |
+|---------------------------------------------|--------------------------------------------------------------------------|-----------------------|-----------|
+| Curated metagenomic data [@pasolli2017]     | curatedMetagenomicData [@pasolli2017]                                    | 93                    | 22,588    |
+| HoloFood [@rogers2024]                      | HoloFoodR [@holofoodr]                                                   | -                     | 9,990     |
+| MGnify [@gurbich2023]                       | MGnifyR [@mgnifyr]                                                       | 5,129                 | 629,821   |
+| microbiomeDataSets [@microbiomedatasets]    | microbiomeDataSets [@microbiomedatasets]                                 | 6                     | 19,100    |
+| Microbiome Benchmark Data [@gamboa-tuz2025] | MicrobiomeBenchmarkData [@gamboa-tuz2025]                                | 6                     | 1,125     |
+| Human Microbiome Project 2 [@hmp2data]      | HMP2data [@hmp2data]                                                     | 3                     | 11,493    |
+| A compilation of open microbiome datasets   | [https://github.com/microbiome/data](https://github.com/microbiome/data) | 8                     | 18,777    |
+
+: Auxiliary open microbiome data resources (last accessed on 29/09/2025).
+{#tbl-dataresources tbl-colwidths="[30,40,15,15]"}
+
+# Data preparation {#sec-process}
+
+While several tools for microbiome data analysis are available [@jeganathan2021; @willis2019;
+@marcoszambrano2023], their implementations typically differ in terms of
+expected input and output formats. Common data standards promote
+modular data science workflows, speeding up methods development,
+benchmarking, and replication. Building upon these principles, we describe a set
+of interoperable software libraries that support microbiome data integration and
+analysis based on the two integrative data containers, TreeSE and MAE
+(Figure \ref{fig:workflow}).
+
+This framework specifically supports the downstream analysis of
+high-throughput sequencing data from microbiome experiments after summarizing
+the original measurements into abundance
+tables (*e.g.*, taxonomic or functional profiles). Taxonomic
+abundance tables are one of the most commonly encountered data types.
+Common measurement platforms include amplicon-based marker gene
+studies (*e.g.*, 16S rRNA) and metagenomic sequencing, but alternative profiling
+techniques are available including phylogenetic microarrays
+[@rajilicstojanovic2009] and high-density optical mapping
+[@abakumov2024]. The interoperability of the data containers
+support modular workflow design for integrating different
+omics data types into the broader Bioconductor ecosystem. This
+mitigates reproducibility challenges posed by rapidly
+evolving reference databases and profiling tools
+(*e.g.*, MetaPhlAn2 vs. MetaPhlAn4) by enabling structured coexistence and
+direct comparison within a unified, coherent framework
+[@blanco2023; @truong2015].
+
+**Data import.** While the TreeSE data container can be populated with microbiome
+data from common tabular data types, certain non-standard file formats may
+require additional data wrangling. To streamline data
+import, we provide importers for a variety of standard microbiome file
+formats including BIOM [@mcdonald2012], MetaPhlAn/HUMAnN (MetaPhlAn
+v. 2&ndash;4, HUMAnN v. 3) [@mciver2017], Mothur [@schloss2009], QIIME 2
+[@bolyen2019] and the TAXonomic Profile Aggregation and
+standardization format (taxpasta) [@beber2023]. These importers bridge the gap
+between the raw sequence processing and downstream statistical analysis in R,
+allowing researchers to focus on interpreting biological patterns rather than
+wrangling file formats. Moreover, converters between alternative data
+structures in R are available supporting seamless conversions between TreeSE
+and BIOM, DADA2 [@callahan2016] and phyloseq (the mia::convert\* functions).
+Similarly, microbiome data stored in TreeSE objects can also be
+exported to external services
+such as MicrobiomeDB [@oliveira2018] and other languages
+(*e.g.*, Julia). These converters facilitate widespread access to
+microbiome analysis methods. Imported datasets from different omics modalities
+can then be interlinked within the MAE data container with its flexible sample
+mappings as described above. This integrated data object can then be analyzed
+with dedicated downstream methods.
+
+**Quality control and exploration.** After importing the data into R,
+the recommended first step involves basic data exploration and quality
+control [@zuur2010]. In addition to methods for identifying
+contaminant sequences and calculating summary statistics, the
+framework includes a versatile set of custom visualization methods to
+assess data variability, outliers, homogeneity of variance and other
+aspects that may need to be considered in downstream data
+analysis. The mia and miaViz packages provide
+convenient access to many operations for the integrative
+data containers regarding common tasks in microbiome
+data exploration and visualization (@fig-downstream_analyses).
+
+**Filtering and agglomeration.** Microbiome datasets can contain tens of
+thousands of unique features depending on the sequencing resolution, used
+reference databases, and the scope of analysis. Moreover, the integration of
+multiple omics modalities adds another level of challenges. To summarize data
+into biologically meaningful groups or to reduce multiple comparisons the data
+is often subsetted, filtered or agglomerated to higher-level taxonomic or
+functional categories or stratified by sample groups. The package ecosystem,
+and the mia package in particular, feature various tools for such tasks.
+For instance, the prevalence-based methods can be
+helpful to remove rare features that are likely sequencing artifacts
+or present otherwise limited value for the analysis. The mechanism of
+alternative experiments (altExp) allows agglomeration
+by taxonomic levels or other features such as
+pathogenicity or functional potential (*e.g.*, butyrate production
+[@kullberg2024], gut-brain modules [@vallescolomer2019], and other
+host-associated signatures [@geistlinger2024]). The agglomerated data can be
+incorporated as a new alternative experiment within the original data object.
+The automated tracking of feature and sample links ensures that
+changes are propagated across all relevant elements of the data object,
+such as transformed abundance tables, phylogenetic trees, or interlinked
+omics modalities. This helps to avoid redundant processing and enables
+efficient management of interlinked multi-modal datasets.
+
+**Transformation.** Statistical transformations commonly used in microbiome
+research include relative abundance [@gloor2017],
+tree-aware phylogenetic ILR (phILR) [@silverman2017], centered log-ratio (CLR),
+and robust CLR (rCLR). The latter three aim to mitigate
+compositionality bias [@martino2019]. A related concept that controls for
+unequal sampling depth is data rarefaction. Rarefaction is
+the process of repeatedly subsampling data to equal read depth and averaging
+computed metrics [@schloss2024b]. Subsampling data to equal read depth
+(*rarefying*) without iteration is not recommended
+[@mcmurdie2014; @schloss2024; @willis2019b]. Our framework supports these and a
+variety of other transformations commonly applied to microbiome data.
+
+**Data enrichment.** Incorporating additional data, such as new versions of
+feature abundance data resulting from data transformations, is a
+frequent operation in applied data analysis, and it often takes place
+iteratively. The integrative data containers
+support gradual and organized accumulation of interlinked data elements
+including transformations, aggregated data, dimension reduction, and derived
+data on samples and features. We generally recommend
+initializing the data objects at the beginning of the
+workflow, where they can then be gradually enriched as the project advances.
+Data can be enriched by importing new external information as well as by
+deriving new information from the data itself into the same data container as
+described in the next section. By systematically extending the upstream data
+preparation step&mdash;instead of ad-hoc calculations scattered amidst the
+workflow&mdash;one can achieve a well-organized and transparent
+provenance of the integrated data object.
+
+::: {.figure}
+\begin{center}
+\includegraphics[height=\textheight]{figures/workflow.png}
+\end{center}
+\captionof{figure}{\textbf{Multi-modal data integration workflow.} Following
+data generation and preprocessing (top two panels), the integrative framework
+covers five steps of microbiome data integration and analysis: 1) Data is
+wrapped into a TreeSE data object (Figure~\ref{fig-datacontainers}),
+containing information on the samples (tube icons) and their features
+(\textit{e.g.} taxonomic, functional, or resistome profiles; colored circles).
+TreeSE objects can accommodate multiple assay tables as well as additional
+hierarchical structures. 2) The TreeSE data object can then be processed to get
+cleaner data. This can include filtering out low-quality samples and features,
+transforming assay data for example by normalizing it to enhance the
+comparability of sample-specific abundances, or agglomerating the feature data
+to specific taxonomic levels or functional categories. 3) The cleaned data can
+then be analyzed using statistical models to uncover relations among samples
+(\textit{e.g.}, with ordination methods), analyze drivers of variation in community diversity
+and composition or test for differential abundance (\textit{e.g.} between
+sampling time or location). 4) The framework supports the integration of
+various types of omics modalities through MAE and 
+omic-specific data containers provided by Bioconductor. Here,
+for example, the taxonomic and metabolomic profiles of samples can be summarized
+and compared with joint analysis among features. 5) Finally, Quarto notebooks
+can aid reproducible analysis and reporting.}
+\label{fig:workflow}
+:::
+
+# Downstream data analysis {#sec-analysis}
+
+This framework is designed to improve the management of integrative analysis
+workflows. It facilitates joint operations on interlinked data elements,
+helping to shift the focus towards multi-modal analyses and
+methods development while also supporting standard data analyses in
+microbiome research.
+
+Microbiome data analysis often relies on specialized statistical approaches,
+since data sparsity, zero-inflation, compositionality, and heteroscedasticity
+pose challenges for standard methods [@gloor2017; @jeganathan2021].
+Furthermore, microbiome data is hierarchically
+structured across taxonomic, ecological, temporal, and spatial levels
+[@moreno-indias2021; @ruuskanen2021]. Alternative processing pipelines
+introduce different biases and generate varying data formats; for example, the
+same sample can yield differing taxonomic profiles depending on the
+computational method used [@quince2017]. These and other unique characteristics
+have wide-reaching implications for microbiome analysis, necessitating dedicated
+analysis methods [@moreno-indias2021]. The shared data containers
+support community-driven development and reproducible benchmarking of methods.
+The following sections provide an overview of some of the currently
+available tools, encompassing standard methods for taxonomic and other
+abundance tables as well as integrative analyses between modalities.
+
+**Community indicators.** Various general indicators are available
+to quantify the microbial community state or other sample
+properties. Community diversity represents a common measure in
+microbial ecology [@bastiaanssen_bugs1_2023]
+(@fig-downstream_analyses). Alpha diversity metrics generally quantify
+the observed or estimated number of distinct taxa (_richness_) and
+their distribution (_evenness_). Many diversity indices (*e.g.*,
+Shannon index), combine these two aspects. Phylogenetic diversity
+metrics additionally account the breadth of phylogenetic relatedness among
+community members [@faith1992], but are more computationally demanding than
+abundance-based metrics. However, a new implementation of the Stacked Faith's
+Phylogenetic Diversity improves computational efficiency by 1&ndash;2
+orders of magnitude [@armstrong2021]. The framework supports analyses
+with rarefaction through the mia package [@schloss2024b]. Other
+global indices of community state include measures of dominance,
+rarity, skewness, kurtosis, modality, library size (number of reads),
+or absolute abundance quantification. Sample information in the TreeSE object
+(colData) can be enriched with these derived quantities. By default,
+the mia::addAlpha method returns a set of complementary alpha
+diversity measures [@cassol2025]. Alpha diversity indices have been frequently
+applied to measure not only taxonomic diversity but also resistome
+diversity [@salehi2025], and potentially other modalities.
+
+**Community similarity** is commonly evaluated with beta diversity
+measures, which quantify multivariate dissimilarity between feature communities
+across all pairs of samples and can be used to
+compare community composition quantitatively. The
+framework supports common dissimilarity metrics in microbial ecology,
+including Bray-Curtis, Jaccard, Aitchison
+[@bastiaanssen_bugs1_2023; @martino2019],
+and the phylogeny-aware UniFrac [@lozupone2005]. Community
+dissimilarity is commonly visualized with unsupervised ordination
+methods that project the data onto a lower-dimensional space
+[@goodrich2014]. Among unsupervised techniques, the most commonly used ones
+include Principal Component Analysis (PCA) and Principal Coordinate Analysis
+(PCoA), which encompasses both metric and non-metric multidimensional scaling
+(@fig-downstream_analyses). Statistical tests
+(*e.g.*, PERMANOVA) and supervised
+ordination methods, such as
+distance-based Redundancy Analysis (dbRDA), can complement the
+unsupervised analyses, and help uncover and quantify covariation
+between community composition and sample-specific covariates. This type of analysis can benefit
+from compositionally robust measures (*e.g.*, robust
+Aitchison distance [@martino2019]), or phylogeny-aware dissimilarity
+measures specifically developed for microbiome research (*e.g.*, UniFrac
+[@lozupone2005]). Sample dissimilarity provides the basis for many
+specialized microbiome techniques, including microbial community typing
+(clustering) with Dirichlet multinomial mixtures [@holmes2012]
+and community state types [@digiulio2015], or factorization into
+community signatures [@frioux2023]. These and other multivariate
+methods are provided by mia, miaViz, and additional single-cell packages
+(scater, scuttle [@amezquita2020]). Quantification of sample dissimilarities is
+a common task, and many omics modalities can benefit from shared,
+standardized methods provided by the integrative (Tree)SE framework.
+
+**Differential abundance and mediation analysis.** Differential Abundance
+Analysis (DAA)
+and Differential Prevalence Analysis (DPA) methods are used to
+identify indicator microbial features whose abundances vary across study groups
+or continuous gradients, for example in terms of spatial or temporal distance between
+samples (@fig-downstream_analyses). Most DAA methods used in microbiome research
+support the (Tree)SE framework, such as
+ANCOM-BC2 [@lin2024], LimROTS [@anwar2025], MaAsLin3
+[@nickols2024], and radEmu [@clausen2024]. Leveraging the interoperability of
+this framework, several of these methods have also found
+applications with other omics modalities, including transcriptomics
+[@love2014], metabolomics [@nickols2024], and proteomics [@anwar2025].
+Importantly, recent studies have indicated that elementary methods, such as log-transformed
+Total Sum Scaled (TSS) counts coupled with a linear model, or
+presence/absence data with logistic regression, often yield the most consistent
+results [@pelto2025; @gamboa-tuz2025]. Standard DAA typically focuses on
+individual features, ignoring interactions or other covariation among feature
+abundances. Thus, we support covariation analyses. While agglomerating collinear
+features as a preprocessing step can reduce multiple testing, increase
+statistical power, and improve interpretability, it is also prone to subjective
+parameterization and limited generalizability. Feature can be grouped
+based on clustering results from
+abundance profiles or on external information drawn from phylogenetic
+relations, taxonomic classifications or functional properties
+(*e.g.*, aggregating based on metabolite production [@kullberg2024]). Beyond these,
+early implementations of advanced methods, such as causal mediation
+analysis tailored to microbiome multi-omics data, have been implemented for
+SE [@jiang2025], highlighting its readiness to support the adoption of
+constantly developing methodology.
+
+**Function- and sequence-level analyses.** Taxonomic analysis is
+frequently complemented by functional analyses, either based on
+functional predictions derived from amplicon or metagenomic
+sequences, or from parallel metabolomic, metatranscriptomic or other functional
+assays. Our framework not only supports the incorporation of functional
+abundance tables within the same data objects, but many statistical methods implemented in the ecosystem are generic and can therefore be applied across
+different omics data types. Where appropriate, specialized methods are also
+available; for instance, regarding metabolome
+analyses, the notame package [@klavus2020] has recently added SE support,
+and the R4MS project provides many interoperable tools [@gatto2025].
+The framework has found recent applications in extended analyses of metagenomic
+features, for instance, antimicrobial resistome composition [@salehi2025].
+We have also converted a large-scale compilation of resistome profiles in 8,972
+metagenome samples [@lee2023] into the TreeSE format to support
+research and training activities in this area of microbiome analysis.
+
+**Spatio-temporal, ecological, and epidemiological models.** Microbiome time
+series [@berg2020] encompass a wide range of study designs, ranging
+from short to long follow-up times, sparse to dense data, univariate
+to multivariate and multi-omic monitoring [@velten2022], and real,
+pseudo, or simulated time series. Moreover, an increasing number of
+studies incorporate spatial dimension in microbiome analysis [@ruuskanen2021].
+While spatio-temporal analyses require specialized methods, the miaTime R
+package offers a set of data wrangling methods to support longitudinal,
+multi-modal microbiome analysis. In addition, Bioconductor contains applicable
+methods from other research domains, namely single-cell omics
+[@amezquita2020] and spatial transcriptomics [@crowell2025], which use closely
+related data containers. Spatial and temporal information can be
+incorporated as a covariate (*e.g.*, location or time) or by estimating
+temporally or spatially resolved metrics, such as divergence (dissimilarity
+between consecutive time points), autocorrelation (similarity of closely
+related samples), and feature modality (whether a feature exhibits multiple
+abundance states). Another type of temporal analysis
+includes the time-to-event, or survival models, which are encountered
+regularly in epidemiological and population cohort studies; for microbiome
+data, these analyses require specialized approaches, as proposed in previous
+studies [@salosensaari2021; @calle2023]. We also provide methods to simulate
+time series from standard models of microbial community dynamics including
+Hubbell's neutral model, generalized Lotka-Volterra, and the
+consumer-resource model through the miaSim package [@gao2023]. Our framework
+provides a robust basis for developing extended methods for longitudinal
+multi-omics, which is currently an active area of investigation [@sherwani2025].
+
+**Multi-modal integration.** A key benefit of the ecosystem lies in its ability
+to support the integration of microbial abundance data with other omics
+modalities, such as resistomes [@salehi2025], metabolomes [@hintikka2021],
+host genomes [@qin2022], transcriptomes, or proteomes
+[@nyholm2020; @moreno-indias2021] (@fig-downstream_analyses). As we have
+demonstrated, the integrative data containers support complex combinations of
+omics datasets [@huber2015; @ramos2017; @amezquita2020]. By leveraging
+standardized multi-assay data structures, users can apply a growing
+number of integrative methods for multi-omics analysis. This eliminates the
+need for manual data wrangling, reduces the risk of errors (*e.g.*, sample
+mismatches), and enables the creation of modular, efficient, and reproducible
+workflows. Such integrative approaches in microbiome
+research can be broadly categorized into three groups: Machine Learning (ML)
+prediction, association-based approaches, and
+latent variable modeling [@jeganathan2021; @sherwani2025;
+@moreno-indias2021; @mallick2024; @bastiaanssen2023;
+@argelaguet2020; @singh2019; @mangnier2025].
+ML approaches aim to integrate multiple omics modalities into a
+single predictive model. However, naive concatenation of feature tables can
+obscure modality-specific signals and reduce predictive performance. Methods
+such as IntegratedLearner [@mallick2024] address this limitation by modeling
+each modality separately while leveraging their complementary predictive
+information within a unified framework.
+Association-based methods aim to quantify relationships between datasets.
+Whereas the cross-correlation analysis can be used to capture direct
+associations of samples or features between two datasets, anansi can supervise
+such analyses  by incorporating known functional relations. While these
+association-based approaches are often easier to interpret, they do not
+explicitly account for the fact that microbes operate within complex
+communities. In contrast, latent variable methods such
+as multi-omics factor analysis [@argelaguet2020],
+joint robust PCA [@martino2019] and multiblock partial least
+squares discriminant analysis [@singh2019] model shared latent
+structure across modalities, enabling the discovery and visualization of
+coordinated variation at the community level.
+The available methodologies are rapidly increasing, and we aim to
+accelerate the development, benchmarking, and standardization of
+multi-modal extensions for microbiome analysis through a systematic integrative
+framework proposed here.
+
+**Other methods and programming environments.** Several other methods have
+been employed in microbiome data science. Examples include network analysis
+[@peschel2021], ML-based prediction and classification [@topcuoglu2021], and
+microbe-set enrichment
+analysis [@kou2020; @pham2025]. The recent adoption of interoperable
+data containers and shared methodological approaches in related research fields
+can significantly expand the transfer of existing toolkits to adjacent or emerging
+disciplines. Importantly, this framework enables integration not only within the Bioconductor ecosystem
+but also with external pipelines, including bioBakery [@navarro2024; @mciver2017], and foreign platforms through language-specific interfaces,
+namely `Rcpp` for C+, `reticulate` for Python, and `JuliaCall` for Julia.
+These connections allow users to combine the
+most suitable tools across multiple frameworks, while ensuring
+cross-language interoperability of structured data through standard containers such as TreeSE and MAE.
+
+```{r}
+#| label: downstream_analyses
+#| eval: false
+#| echo: false
+#| message: false
+
+# Load packages
+pkgs <- c("maaslin3", "mia", "miaTime", "microbiomeDataSets")
+temp <- sapply(pkgs, function(x) {
+    suppressMessages(require(x, character.only = TRUE))
+})
+
+# Load data
+tse <- SprockettTHData()
+# Subset by taking only fecal samples from infants
+tse <- tse[, tse[["Sample_Type"]] %in% c("Feces")]
+tse <- tse[, tse[["Age_Class"]] %in% c("Infant")]
+
+# Agglomerate and apply transformations
+tse <- agglomerateByRanks(tse)
+tse <- transformAssay(tse, method = "relabundance", altexp = altExpNames(tse))
+tse <- transformAssay(
+    tse,
+    method = "clr", pseudocount = TRUE, altexp = altExpNames(tse)
+)
+altExp(tse, "prev_genus") <- subsetByPrevalent(
+    altExp(tse, "Genus"),
+    prevalence = 0.5, detection = 0.001
+)
+rownames(altExp(tse, "prev_genus")) <- gsub(
+    "/| ", "_", rownames(altExp(tse, "prev_genus"))
+)
+
+# Calculate alpha diversity
+tse <- addAlpha(tse, index = "faith")
+
+# Perform PCoA
+tse <- addMDS(tse, assay.type = "counts", method = "unifrac", niter = 10L)
+
+# Perform dbRDA
+tse <- addRDA(
+    tse,
+    assay.type = "clr", method = "euclidean",
+    formula = x ~ Age_Months + Country, na.action = na.exclude
+)
+# Remove the RDA object as it takes a lot of space
+attr(reducedDim(tse, "RDA"), "obj") <- NULL
+
+# Perform DAA
+res_full <- maaslin3(
+    input_data = altExp(tse, "prev_genus"),
+    output = "DAA_example",
+    formula = "~ Age_Months + Sex + Country",
+    normalization = "TSS",
+    transform = "LOG",
+    verbosity = "ERROR"
+)
+res <- res_full[["fit_data_abundance"]][["results"]]
+res <- res[res[["value"]] == "Age_Months", ]
+signif_feat <- res[
+    !is.na(res[["qval_individual"]]) & res[["qval_individual"]] < 0.05,
+    "feature"
+]
+rowData(altExp(tse, "prev_genus"))[["signif"]] <- rownames(
+    altExp(tse, "prev_genus")
+) %in% signif_feat
+
+# Calculate time divergence
+tse <- addStepwiseDivergence(
+    tse,
+    time.col = "Age_Months",
+    group = "Subject_ID", method = "bray",
+    tree = rowTree(tse)
+)
+
+# Save object so that it can be used in visualization step without running the
+# analyses
+saveRDS(tse, file.path("data", "tse.rds"))
+```
+
+```{r}
+#| label: fig-downstream_analyses
+#| echo: false
+#| message: false
+#| warning: false
+#| fig-cap: "Common visualization methods applied to time series data on infants
+#|   from three different countries (Finland, Bangladesh, and Bolivia) based on
+#|   public datasets - SprockettTHData()
+#|   [@sprockett2020; @subramanian2014; @vatanen2016] available via
+#|   microbiomeDataSets [@microbiomedatasets]. **a**, Phylogenetic
+#|   relationships. **b**, Phyla abundances of the samples ordered by age,
+#|   stratified by country and gender. Actinobacteria is more abundant in
+#|   Bolivia and Bangladesh compared to Finland.  **c&ndash;d**,
+#|   Multidimensional scaling using UniFrac distances and distance-based
+#|   Redundancy Analysis (dbRDA) based on Aitchison distance, respectively. Both
+#|   ordination methods shows clear pattern separating microbial profiles in
+#|   different countries. dbRDA shows an additional association between
+#|   microbial profile and age. **e&ndash;f**, Faith's phylogenetic diversity by
+#|   country and age respectively. **g**, Differential Abundance Analysis (DAA)
+#|   results. Two genera exhibit an association with age. **h**, UniFrac
+#|   divergence between consecutive time points. Results indicate slow
+#|   stabilization of microbial communities."
+#| fig-width: 19
+#| fig-height: 10
+
+# Load packages
+pkgs <- c("miaViz", "patchwork", "scater")
+temp <- sapply(pkgs, function(x) {
+    suppressMessages(require(x, character.only = TRUE))
+})
+
+# Load data
+file_path <- file.path("data", "tse.rds")
+if (!file.exists(file_path)) {
+    stop("Run manually the chunk above. '", file_path, "' cannot found.")
+}
+tse <- readRDS(file_path)
+
+# Get phylum names
+phylum_names <- sort(unique(rowData(altExp(tse, "Phylum"))[, "Phylum"]))
+# Named vector of phylum colors
+phylum_colors <- setNames(
+    scater:::.get_palette("tableau20")[seq_along(phylum_names)],
+    phylum_names
+)
+
+# Define a font size
+title_size <- 16
+text_size <- 12
+
+# Visualize phylogeny
+p_tree <- plotRowTree(
+    altExp(tse, "Family"),
+    edge.colour.by = "Phylum", layout = "ape"
+) +
+    scale_color_manual(values = phylum_colors) + # Manually set colors
+    guides(color = "none")
+
+# Visualize abundances with barplot
+p_bar <- plotAbundance(
+    altExp(tse, "Phylum"),
+    assay.type = "relabundance",
+    col.var = c("Country", "Sex"), facet.cols = TRUE, scales = "free",
+    order.col.by = "Age_Months"
+) +
+    guides(fill = guide_legend(title = "Phylum")) +
+    scale_color_manual(values = phylum_colors) +
+    theme(
+        axis.title.y = element_text(size = title_size),
+        axis.text.y = element_text(size = text_size)
+    )
+
+# Visualize alpha diversity
+p_alpha <- plotColData(
+    tse,
+    y = "faith", x = "Country", colour_by = "Country",
+    show_boxplot = TRUE, show_violin = FALSE, point_alpha = 0.2
+) +
+    labs(y = "Faith", x = "Country") +
+    theme(
+        legend.position = "none",
+        axis.title.x = element_text(size = title_size),
+        axis.title.y = element_text(size = title_size),
+        axis.text.x = element_text(size = text_size, angle = 20, hjust = 0.6, vjust = 0.8),
+        axis.text.y = element_text(size = text_size)
+    )
+
+p_alpha2 <- plotColData(
+    tse,
+    y = "faith", x = "Age_Months"
+) +
+    geom_smooth(method = "lm") +
+    labs(y = "Faith", x = "Age in months") +
+    theme(
+        axis.title.x = element_text(size = title_size),
+        axis.title.y = element_text(size = title_size),
+        axis.text.x = element_text(size = text_size),
+        axis.text.y = element_text(size = text_size)
+    )
+
+# Visualize PCoA
+p_mds <- plotMDS(tse, colour_by = "Country") +
+    theme(
+        legend.position = "inside",
+        legend.justification = c("right", "top"),
+        axis.title.x = element_text(size = title_size),
+        axis.title.y = element_text(size = title_size),
+        axis.text.x = element_text(size = text_size),
+        axis.text.y = element_text(size = text_size),
+        legend.title = element_text(size = title_size),
+        legend.text = element_text(size = text_size)
+      )
+
+# Visualize dbRDA
+p_rda <- plotRDA(tse, "RDA", colour.by = "Country", add.significance = FALSE) +
+    theme(
+        legend.position = "none",
+        axis.title.x = element_text(size = title_size),
+        axis.title.y = element_text(size = title_size),
+        axis.text.x = element_text(size = text_size),
+        axis.text.y = element_text(size = text_size)
+    )
+
+# Visualize abundances vs age
+p_daa <- plotExpression(
+    altExp(tse, "prev_genus"),
+    features = rownames(altExp(tse, "prev_genus"))[rowData(altExp(tse, "prev_genus"))[["signif"]]],
+    assay.type = "relabundance", x = "Age_Months", ncol = 3L,
+) +
+    scale_y_log10() +
+    geom_smooth() +
+    labs(x = "Age in months", y = "Relative abundance") +
+    theme(
+        axis.title.x = element_text(size = title_size),
+        axis.title.y = element_text(size = title_size),
+        axis.text.x = element_text(size = text_size),
+        axis.text.y = element_text(size = text_size)
+    )
+
+# Visualize divergence
+tse_sub <- tse[, !is.na(tse[["time_diff"]]) & tse[["time_diff"]] >= 0.8 & tse[["time_diff"]] <= 1.2]
+p_divergence <- plotColData(tse_sub, y = "divergence", x = "Age_Months") +
+    geom_smooth(method = "lm") +
+    labs(x = "Age in months", y = expression(Delta ~ "UniFrac" ~ "(N, N-1)")) +
+    theme(
+        legend.position = "none",
+        axis.title.x = element_text(size = title_size),
+        axis.title.y = element_text(size = title_size),
+        axis.text.x = element_text(size = text_size),
+        axis.text.y = element_text(size = text_size)
+    )
+
+# Combine plots
+p1 <- (p_tree / p_bar) +
+    plot_layout(guides = "collect")
+p2 <- (p_mds / p_rda) +
+    plot_layout(heights = c(1, 1))
+p3 <- ((p_alpha | p_alpha2) / p_daa / p_divergence) +
+    plot_layout(heights = c(1, 1, 1))
+p <- (p1 | p2 | p3) +
+    plot_layout(widths = c(0.33, 0.4, 0.32)) +
+    plot_annotation(tag_levels = "a") &
+    theme(plot.tag = element_text(size = 22, face = "bold"))
+p
+```
+
+# Accessible analysis and community {#sec-community}
+
+Modern science is embodied by a critical community capable of
+assessing discoveries and replicating results [@wootton2016].
+Open source developer communities present a timely manifestation of this
+principle, with technical, legal, sociological and epistemic consequences
+[@hocquet2024]. FAIR principles for software support inclusive
+access to well-documented and user-friendly methods [@barker2022],
+and are facilitated by the extensive quality control and
+documentation standards of Bioconductor [@huber2015].
+In addition to these technical
+demands, the development and quality control of research software
+significantly relies on a strong community engagement, which
+stimulates continuous software improvement and promotes the emergence and
+dissemination of evidence-based best practices [@berg2020;
+@barker2022; @hocquet2024]. We recommend starting with simple
+methods [@pelto2025], calculating derived quantities such
+as diversity, prevalence, and other such measures early in
+the workflow, and complementing analyses with visual exploration. These
+practices can improve the transparency and interpretability of the
+analysis and its results. Expressive code and meaningful comments support
+reproducibility and verification.
+
+Harmonized data structures and access to validated methods support standardized
+and transparent data wrangling across studies while facilitating method sharing,
+benchmarking, and reproducible comparisons. These capabilities help establish
+community best practices and build consensus while allowing users to flexibly
+select and evaluate methods appropriate for their specific data and research
+questions. The Bioconductor framework naturally aligns with these goals through
+its open ecosystem of data resources, interoperable software, and educational
+materials. Community building is actively supported through online training
+resources and communication channels, making it easier for both developers and
+users to contribute to the continued development and standardization of the
+ecosystem. Together with interactive applications, these resources offer
+accessible entry points for developers and users, regardless of their
+programming experience.
+
+**The OMA book.** _Orchestrating Microbiome Analysis with Bioconductor_ (OMA)
+is an online book published at [https://bioconductor.org/books/release/OMA](https://bioconductor.org/books/release/OMA)
+that provides a comprehensive guide to the (Tree)SE framework for microbiome
+data science in Bioconductor, including practical guidelines,
+reproducible workflows, and training material for integrative microbiome
+analyses. The book is versioned according to Bioconductor's biannual software
+release cycles. The work incorporates rich feedback from the user community and
+microbiome training courses. The OMA book aligns to a broader Bioconductor convention, where
+prominent data structures [@huber2015; @ramos2017; @huang2021]
+designed for multi-table data integration have been described across several
+domains, such as single-cell omics
+(OSCA book [@amezquita2020]) and spatial transciptomics (OSTA book [@crowell2025]).
+These resources
+demonstrate how standard data containers can support statistical
+programming on interlinked multi-table datasets.
+
+**Interactive applications.** Graphical user interfaces provide
+accessible entry points to the framework. The iSEEtree and miaDash
+packages provide interactive analysis and visualization tools for
+microbiome data [@benedetti2025]. The former extends iSEE to provide support for
+TreeSE objects, while the latter builds on iSEEtree to enable analyses without
+requiring any programming. Their interface supports automatic generation of
+source code and replicable workflows as well as analysis templates for users
+without a strong programming expertise. Moreover, the tidy R paradigm, available
+through tidyomics, simplifies the syntax and streamlines analytical
+workflows [@hutchison2024]. These tools allow users to analyze and
+visualize complex data combinations with ease.
+
+**Community.** Its widespread adoption has made R one of the most cited software
+resources of our time [@pearson2025] and the introduction of the
+shared data structures facilitates the broad interoperability of the
+methods ecosystem. Bioconductor has a strong tradition in fostering the
+R user community through shared data structures and training activities
+[@drnevich2025]. An active community of developers and users thrives online,
+supporting the software sustainability and promoting good practices in
+scientific computing [@wilson2017]. The community interacts via several online
+communication channels, including Bioconductor Zulip, GitHub platform,
+and an email list. The development of the framework is influenced by
+feedback from the user community through these channels, regular
+meetings, and training workshops.
+
+# Alternative frameworks {#sec-data_frameworks}
+
+Several data analytical frameworks are available for microbiome data science,
+each distinguished by its underlying paradigms, user communities, and scope.
+For example, tools such as QIIME 2 [@bolyen2019], Anvi'o
+[@eren2021], and Mothur [@schloss2009] emphasize standardized, modular
+approaches tailored to microbiome analysis. These frameworks provide
+validated and user-friendly solutions, enabling development of efficient
+end-to-end workflows for microbiome research. However, they are typically
+designed around specific data types, which limits flexibility
+when integrating heterogeneous data modalities within a unified analytical
+framework. In contrast, Bioconductor embraces a more exploratory, statistically
+oriented paradigm spanning multiple areas of bioinformatics beyond
+microbiome research.
+
+TreeSE also offers
 substantial gains in computing speed and memory efficiency over phyloseq
 (@fig-benchmarking). While speedyseq is faster in certain operations, TreeSE
 tends to scale more efficiently in terms of execution time (t) and allocated
@@ -589,6 +1358,28 @@ preserving familiar coding patterns and minimizing changes to established
 analysis pipelines. Despite the advantages of the (Tree)SE framework,
 further optimization of time and memory consumption remains an area for future
 development.
+
+This data analytical paradigm of Bioconductor is similar to scikit-bio's
+[@aton2025]. While scikit-bio as a Python-based ecosystem benefits from rapidly
+evolving machine learning and artificial intelligence tools, Bioconductor’s
+strengths lie in its vast statistical ecosystem dedicated to omics research and
+strong interoperability with other computational environments.
+Another key distinction is community structure: scikit-bio is more
+centralized, whereas Bioconductor packages are developed and maintained by an
+open community, resulting in a broad toolkit and collaboration enabling easy
+reuse of common solutions.
+Although this approach can introduce some challenges, such as dependency management,
+package compatibility, and differences in package stability, these are actively
+addressed through several coordinated mechanisms. First, submitted packages undergo
+peer review, ensuring relevance and adherence to standards such as documentation
+and working examples. Secondly, Bioconductor follows synchronized, semiannual
+release cycle, during which packages are frozen and mutually compatible. Thirdly,
+all packages are continuously tested within Bioconductor's automated build system,
+which ensures that breaking changes are rapidly detected before release. Each package has an active
+maintainer who is notified of failures and resolves them in a timely manner.
+Finally, community guidelines and continuous integration practices, together
+with shared data structures such as (Tree)SummarizedExperiment, further improve
+interoperability between packages.
 
 ```{r}
 #| label: benchmark_analysis
@@ -855,798 +1646,6 @@ p <- (p1 / p2) +
 p
 ```
 
-**Multi-assay data structures.** Contemporary microbiome research frequently
-involves data across multiple measurement modalities for enhanced functional
-and mechanistic insights. This brings the need to find an appropriate
-representation for each data type and map the links between them. Whereas the
-TreeSE data container is broadly applicable to different modalities such as
-taxonomic, resistome, transcriptome, proteome, and metabolome profiling data,
-dedicated data containers have been developed for certain modalities by the
-Bioconductor community to address their specific characteristics; examples
-include single cell sequencing [@amezquita2020] and host genomics
-[@lawrence2013]. Linking data across modalities presents an additional technical
-challenge, as multi-omics datasets are often sparse and only a subset of the
-samples may be shared across multiple modalities [@sherwani2025]. In other
-cases, a single sample in one modality may link to several samples in
-another modality [@husso2023] (*e.g.*, due to technical or spatial replication).
-These scenarios require the ability to integrate multiple
-data modalities into a single object and create flexible sample mappings across them.
-The MultiAssayExperiment (MAE) data container [@ramos2017] addresses these
-challenges by introducing a formal mapping layer (sampleMap) that links
-biological samples to their corresponding measurements in each modality
-(@fig-datacontainers b). This design supports one-to-one, one-to-many, and
-partially overlapping sample relationships across experiments. Importantly, this
-mapping is also accessible for downstream operations. For instance when
-subsetting a MAE object
-(*e.g.*, selecting samples with both microbiome and metabolome data), the
-framework automatically resolves the intersection of available samples and
-ensures consistent alignment across all modalities. Such structured handling of
-sample relationships is particularly important for integrative methods, as it
-reduces the risk of sample mismatches, a common source of irreproducibility in
-ad hoc multi-table analyses. For instance, diagonal integration methods
-[@xu2022; @argelaguet2021computational]&mdash;where shared features across
-data types may not be explicitly defined&mdash;can benefit from
-such a systematic framework that enforces anchor alignment. This reflects lessons
-learned from single-cell data integration, where shared anchors and hierarchical
-mapping have proven essential for interpretability. To summarize, flexible mapping of samples
-across several data objects is key for efficient data integration, method sharing,
-and overall interoperability.
-
-@tbl-containers summarizes the integrative data containers for microbiome
-analysis, whereas @tbl-elements introduces the available data elements in each
-container.
-
-| Data container                                | Target use                                                  |
-|-----------------------------------------------|-------------------------------------------------------------|
-| SummarizedExperiment (SE)[@huber2015]         | generic container linking multiple data tables (assays)     |
-| TreeSummarizedExperiment (TreeSE)[@huang2021] | extension incorporating hierarchical data structures        |
-| MultiAssayExperiment (MAE)[@ramos2017]        | binding omic-specific containers in multi-omics experiments |
-
-: Integrative data containers for microbiome analysis.
-{#tbl-containers tbl-colwidths="[50,50]"}
-
-| Slot          | Content                                      | SE | TreeSE | MAE$^a$ |
-|---------------|----------------------------------------------|:--:|:------:|:-------:|
-| **Tables**    |                                              |    |        |         |
-| assays        | tables of features (rows) and samples (cols) | X  | X      | X       |
-| altExps$^b$   | experiments with variable number of features |    | X      | X       |
-| reducedDims   | results of dimensionality reduction          |    | X      | X       |
-| **Rows**      |                                              |    |        |         |
-| rowData       | side information on features                 | X  | X      | X       |
-| rowPairs      | linkage between pairs of associated features |    | X      | X       |
-| rowTrees      | hierarchical organization of features        |    | X      | X       |
-| referenceSeq  | reference sequences of features              |    | X      | X       |
-| **Columns**   |                                              |    |        |         |
-| colData       | side information on samples                  | X  | X      | X       |
-| colTrees      | hierarchical organization of samples         |    | X      | X       |
-| sampleMap$^c$ | flexible sample mapping across experiments   |    |        | X       |
-| **Other**     |                                              |    |        |         |
-| metadata      | additional information on the experiment     | X  | X      | X       |
-
-: Key data elements in the integrative data containers.
-{#tbl-elements tbl-colwidths="[17,63,3,9,8]"}
-
-$^a$ While MAE does not contain conventional slots (with the exception
-of colData), its experiments can include any number of data containers that
-provide those slots. $^b$ altExp samples must match assay samples in a 1-to-1
-mapping. $^c$ The sampleMap supports diverse mappings between samples from
-different experiments (1-to-1, 1-to-many, many-to-1 and many-to-many).
-
-![**Bioconductor data containers for microbiome data.** **(a)
-TreeSummarizedExperiment (TreeSE)** supports hierarchical, multi-table
-microbiome analysis. A data object can accommodate: i) “assays” that describe
-the abundances of features in each sample (*e.g.* taxonomic units, resistance
-genes, or predicted functions), ii) “colData” with tabular metadata on each
-sample, iii) “rowData” with tabular metadata on each feature (*e.g.* taxonomic
-mappings), and iv) tree information describing feature hierarchies, such as
-phylogenetic relations between the taxonomic units (rowTree) or host species
-(colTree). TreeSE can thus link multiple numeric abundance tables and their
-derived versions (*e.g.* statistical transformations, different taxonomic
-levels, dimensionality reduction) with tabular and hierarchical side
-information on the features (rows) and samples (columns). Additional slots for
-reference sequences and experiment metadata are available. (Figure adapted from
-[@huang2021]) **(b) MultiAssayExperiment (MAE)** facilitates the integration of
-interlinked datasets that may represent different omics modalities
-linked by potentially non-trivial sample mappings. (Figure adapted from
-[@ramos2017])](figures/data_containers.png){#fig-datacontainers}
-
-**Data resources.** Several open microbiome data resources are supported,
-enabling direct data import into the aforementioned data containers for further
-downstream analysis within the Bioconductor methods ecosystem
-(@tbl-dataresources). Examples of the available data resources include
-curatedMetagenomicData [@pasolli2017], HoloFood [@rogers2024],
-microbiomeDataSets [@microbiomedatasets], and the EBI/MGnify database
-[@gurbich2023]. In addition, Bioconductor packages often
-include built-in demonstration datasets. Collectively, these resources
-encompass taxonomic and functional profiles from thousands of
-published microbiome studies and tens of thousands samples that can
-be accessed with the available tools for research and educational purposes.
-
-| Data resource                               | Package                                                                  | # studies or datasets | # samples |
-|---------------------------------------------|--------------------------------------------------------------------------|-----------------------|-----------|
-| Curated metagenomic data [@pasolli2017]     | curatedMetagenomicData [@pasolli2017]                                    | 93                    | 22,588    |
-| HoloFood [@rogers2024]                      | HoloFoodR [@holofoodr]                                                   | -                     | 9,990     |
-| MGnify [@gurbich2023]                       | MGnifyR [@mgnifyr]                                                       | 5,129                 | 629,821   |
-| microbiomeDataSets [@microbiomedatasets]    | microbiomeDataSets [@microbiomedatasets]                                 | 6                     | 19,100    |
-| Microbiome Benchmark Data [@gamboa-tuz2025] | MicrobiomeBenchmarkData [@gamboa-tuz2025]                                | 6                     | 1,125     |
-| Human Microbiome Project 2 [@hmp2data]      | HMP2data [@hmp2data]                                                     | 3                     | 11,493    |
-| A compilation of open microbiome datasets   | [https://github.com/microbiome/data](https://github.com/microbiome/data) | 8                     | 18,777    |
-
-: Supporting open microbiome data resources (accessed 29/09/2025).
-{#tbl-dataresources tbl-colwidths="[30,40,15,15]"}
-
-# Data preparation {#sec-process}
-
-While several tools for microbiome data analysis are available [@jeganathan2021; @willis2019;
-@marcoszambrano2023], their implementations typically differ in terms of
-expected input and output formats. Common data standards promote
-modular data science workflows, speeding up methods development,
-benchmarking, and replication. Building upon these principles, we describe a set
-of interoperable software libraries that support microbiome data integration and
-analysis based on the two integrative data containers, TreeSE and MAE
-(Figure \ref{fig:workflow}).
-
-This framework specifically supports the downstream analysis of
-high-throughput sequencing data from microbiome experiments after summarizing
-the original measurements into abundance
-tables (*e.g.*, taxonomic or functional profiles). Taxonomic
-abundance tables are one of the most commonly encountered data types.
-Common measurement platforms include amplicon-based marker gene
-studies (*e.g.*, 16S rRNA) and metagenomic sequencing, but alternative profiling
-techniques are available including phylogenetic microarrays
-[@rajilicstojanovic2009] and high-density optical mapping
-[@abakumov2024]. The interoperability of the data containers
-support modular workflow design for integrating different
-omics data types into the broader Bioconductor ecosystem. This
-mitigates reproducibility challenges posed by rapidly
-evolving reference databases and profiling tools
-(*e.g.*, MetaPhlAn2 vs. MetaPhlAn4) by enabling structured coexistence and
-direct comparison within a unified, coherent framework
-[@blanco2023; @truong2015].
-
-**Data import.** While the TreeSE data container can be populated with microbiome
-data from common tabular data types, certain non-standard file formats may
-require additional data wrangling. To streamline data
-import, we provide importers for a variety of standard microbiome file
-formats including BIOM [@mcdonald2012], MetaPhlAn/HUMAnN (MetaPhlAn
-v. 2&ndash;4, HUMAnN v. 3) [@mciver2017], Mothur [@schloss2009], QIIME 2
-[@bolyen2019] and the TAXonomic Profile Aggregation and
-standardization format (taxpasta) [@beber2023]. These importers bridge the gap
-between the raw sequence processing and downstream statistical analysis in R,
-allowing researchers to focus on interpreting biological patterns rather than
-wrangling file formats. Moreover, converters between alternative data
-structures in R are available supporting seamless conversions between TreeSE
-and BIOM, DADA2 [@callahan2016] and phyloseq (the mia::convert\* functions).
-Similarly, microbiome data stored in TreeSE objects can also be
-exported to external services
-such as MicrobiomeDB [@oliveira2018] and other languages
-(*e.g.*, Julia). These converters facilitate widespread access to
-microbiome analysis methods. Imported datasets from different omics modalities
-can then be interlinked within the MAE data container with its flexible sample
-mappings as described above. This integrated data object can then be analyzed
-with dedicated downstream methods.
-
-**Quality control and exploration.** After importing the data into R,
-the recommended first step involves basic data exploration and quality
-control [@zuur2010]. In addition to methods for identifying
-contaminant sequences and calculating summary statistics, the
-framework includes a versatile set of custom visualization methods to
-assess data variability, outliers, homogeneity of variance and other
-aspects that may need to be considered in downstream data
-analysis. The mia and miaViz packages provide
-convenient access to many operations for the integrative
-data containers regarding common tasks in microbiome
-data exploration and visualization (@fig-downstream_analyses).
-
-**Filtering and agglomeration.** Microbiome datasets can contain tens of
-thousands of unique features depending on the sequencing resolution, used
-reference databases, and the scope of analysis. Moreover, the integration of
-multiple omics modalities adds another level of challenges. To summarize data
-into biologically meaningful groups or to reduce multiple comparisons the data
-is often subsetted, filtered or agglomerated to higher-level taxonomic or
-functional categories or stratified by sample groups. The package ecosystem,
-and the mia package in particular, feature various tools for such tasks.
-For instance, the prevalence-based methods can be
-helpful to remove rare features that are likely sequencing artifacts
-or present otherwise limited value for the analysis. The mechanism of
-alternative experiments (altExp) allows agglomeration
-by taxonomic levels or other features such as
-pathogenicity or functional potential (*e.g.*, butyrate production
-[@kullberg2024], gut-brain modules [@vallescolomer2019], and other
-host-associated signatures [@geistlinger2024]). The agglomerated data can be
-incorporated as a new alternative experiment within the original data object.
-The automated tracking of feature and sample links ensures that
-changes are propagated across all relevant elements of the data object,
-such as transformed abundance tables, phylogenetic trees, or interlinked
-omics modalities. This helps to avoid redundant processing and enables
-efficient management of interlinked multi-modal datasets.
-
-**Transformation.** Statistical transformations commonly used in microbiome
-research include relative abundance [@gloor2017],
-tree-aware phylogenetic ILR (phILR) [@silverman2017], centered log-ratio (CLR),
-and robust CLR (rCLR). The latter three aim to mitigate
-compositionality bias [@martino2019]. A related concept that controls for
-unequal sampling depth is data rarefaction. Rarefaction is
-the process of repeatedly subsampling data to equal read depth and averaging
-computed metrics [@schloss2024b]. Subsampling data to equal read depth
-(*rarefying*) without iteration is not recommended
-[@mcmurdie2014; @schloss2024; @willis2019b]. Our framework supports these and a
-variety of other transformations commonly applied to microbiome data.
-
-**Data enrichment.** Incorporating additional data, such as new versions of
-feature abundance data resulting from data transformations, is a
-frequent operation in applied data analysis, and it often takes place
-iteratively. The integrative data containers
-support gradual and organized accumulation of interlinked data elements
-including transformations, aggregated data, dimension reduction, and derived
-data on samples and features. We generally recommend
-initializing the data objects at the beginning of the
-workflow, where they can then be gradually enriched as the project advances.
-Data can be enriched by importing new external information as well as by
-deriving new information from the data itself into the same data container as
-described in the next section. By systematically extending the upstream data
-preparation step&mdash;instead of ad-hoc calculations scattered amidst the
-workflow&mdash;one can achieve a well-organized and transparent
-provenance of the integrated data object.
-
-::: {.figure}
-\begin{center}
-\includegraphics[height=\textheight]{figures/workflow.png}
-\end{center}
-\captionof{figure}{\textbf{Multi-modal data integration workflow.} Following
-data generation and preprocessing (top two panels), the integrative framework
-covers five steps of microbiome data integration and analysis: 1) Data is
-wrapped into a TreeSE data object (Figure~\ref{fig-datacontainers}),
-containing information on the samples (tube icons) and their features
-(\textit{e.g.} taxonomic, functional, or resistome profiles; colored circles).
-TreeSE objects can accommodate multiple assay tables as well as additional
-hierarchical structures. 2) The TreeSE data object can then be processed to get
-cleaner data. This can include filtering out low-quality samples and features,
-transforming assay data for example by normalizing it to enhance the
-comparability of sample-specific abundances, or agglomerating the feature data
-to specific taxonomic levels or functional categories. 3) The cleaned data can
-then be analyzed using statistical models to uncover relations among samples
-(\textit{e.g.}, with ordination methods), analyze drivers of variation in community diversity
-and composition or test for differential abundance (\textit{e.g.} between
-sampling time or location). 4) The framework supports the integration of
-various types of omics modalities through MAE and 
-omic-specific data containers provided by Bioconductor. Here,
-for example, the taxonomic and metabolomic profiles of samples can be summarized
-and compared with joint analysis among features. 5) Finally, Quarto notebooks
-can aid reproducible analysis and reporting.}
-\label{fig:workflow}
-:::
-
-# Downstream data analysis {#sec-analysis}
-
-This framework is designed to improve the management of integrative analysis
-workflows. It facilitates joint operations on interlinked data elements,
-helping to shift the focus towards multi-modal analyses and
-methods development while also supporting standard data analyses in
-microbiome research.
-
-Microbiome data analysis often relies on specialized statistical approaches,
-since data sparsity, zero-inflation, compositionality, and heteroscedasticity
-pose challenges for standard methods [@gloor2017; @jeganathan2021].
-Furthermore, microbiome data is hierarchically
-structured across taxonomic, ecological, temporal, and spatial levels
-[@moreno-indias2021; @ruuskanen2021]. Alternative processing pipelines
-introduce different biases and generate varying data formats; for example, the
-same sample can yield differing taxonomic profiles depending on the
-computational method used [@quince2017]. These and other unique characteristics
-have wide-reaching implications for microbiome analysis, necessitating dedicated
-analysis methods [@moreno-indias2021]. The shared data containers
-support community-driven development and reproducible benchmarking of methods.
-The following sections provide an overview of some of the currently
-available tools, encompassing standard methods for taxonomic and other
-abundance tables as well as integrative analyses between modalities.
-
-**Community indicators.** Various general indicators are available
-to quantify the microbial community state or other sample
-properties. Community diversity represents a common measure in
-microbial ecology [@bastiaanssen_bugs1_2023]
-(@fig-downstream_analyses). Alpha diversity metrics generally quantify
-the observed or estimated number of distinct taxa (_richness_) and
-their distribution (_evenness_). Many diversity indices (*e.g.*,
-Shannon index), combine these two aspects. Phylogenetic diversity
-metrics additionally account the breadth of phylogenetic relatedness among
-community members [@faith1992], but are more computationally demanding than
-abundance-based metrics. However, a new implementation of the Stacked Faith's
-Phylogenetic Diversity improves computational efficiency by 1&ndash;2
-orders of magnitude [@armstrong2021]. The framework supports analyses
-with rarefaction through the mia package [@schloss2024b]. Other
-global indices of community state include measures of dominance,
-rarity, skewness, kurtosis, modality, library size (number of reads),
-or absolute abundance quantification. Sample information in the TreeSE object
-(colData) can be enriched with these derived quantities. By default,
-the mia::addAlpha method returns a set of complementary alpha
-diversity measures [@cassol2025]. Alpha diversity indices have been frequently
-applied to measure not only taxonomic diversity but also resistome
-diversity [@salehi2025], and potentially other modalities.
-
-**Community similarity** is commonly evaluated with beta diversity
-measures, which quantify multivariate dissimilarity between feature communities
-across all pairs of samples and can be used to
-compare community composition quantitatively. The
-framework supports common dissimilarity metrics in microbial ecology,
-including Bray-Curtis, Jaccard, Aitchison
-[@bastiaanssen_bugs1_2023; @martino2019],
-and the phylogeny-aware UniFrac [@lozupone2005]. Community
-dissimilarity is commonly visualized with unsupervised ordination
-methods that project the data onto a lower-dimensional space
-[@goodrich2014]. Among unsupervised techniques, those most frequently applied
-include Principal Component Analysis (PCA), Principal Coordinates Analysis
-(PCoA; also known as Multi-Dimensional Scaling, MDS), and Non-metric MDS
-(@fig-downstream_analyses). Statistical tests
-(*e.g.*, PERMANOVA) and supervised
-ordination methods, such as
-distance-based Redundancy Analysis (dbRDA), can complement the
-unsupervised analyses, and help uncover and quantify covariation
-between community composition and sample-specific covariates. This type of analysis can benefit
-from compositionally robust measures (*e.g.*, robust
-Aitchison distance [@martino2019]), or phylogeny-aware dissimilarity
-measures specifically developed for microbiome research (*e.g.*, UniFrac
-[@lozupone2005]). Sample dissimilarity provides the basis for many
-specialized microbiome techniques, including microbial community typing
-(clustering) with Dirichlet multinomial mixtures [@holmes2012]
-and community state types [@digiulio2015], or factorization into
-community signatures [@frioux2023]. These and other multivariate
-methods are provided by mia, miaViz, and additional single-cell packages
-(scater, scuttle [@amezquita2020]). Quantification of sample dissimilarities is
-a common task, and many omics modalities can benefit from shared,
-standardized methods provided by the integrative (Tree)SE framework.
-
-**Differential abundance and mediation analysis.** Differential Abundance
-Analysis (DAA)
-and Differential Prevalence Analysis (DPA) methods are used to
-identify indicator microbial features whose abundances vary across study groups
-or continuous gradients, for example in terms of spatial or temporal distance between
-samples (@fig-downstream_analyses). Most DAA methods used in microbiome research
-support the (Tree)SE framework, such as
-ANCOM-BC2 [@lin2024], LimROTS [@anwar2025], MaAsLin3
-[@nickols2024], and radEmu [@clausen2024]. Leveraging the interoperability of
-this framework, several of these methods have also found
-applications with other omics modalities, including transcriptomics
-[@love2014], metabolomics [@nickols2024], and proteomics [@anwar2025].
-Importantly, recent studies have indicated that elementary methods, such as log-transformed
-Total Sum Scaled (TSS) counts coupled with a linear model, or
-presence/absence data with logistic regression, often yield the most consistent
-results [@pelto2025; @gamboa-tuz2025]. Standard DAA typically focuses on
-individual features, ignoring interactions or other covariation among feature
-abundances. Thus, we support covariation analyses. While agglomerating collinear
-features as a preprocessing step can reduce multiple testing, increase
-statistical power, and improve interpretability, it is also prone to subjective
-parameterization and limited generalizability. Feature can be grouped
-based on clustering results from
-abundance profiles or on external information drawn from phylogenetic
-relations, taxonomic classifications or functional properties
-(*e.g.*, aggregating based on metabolite production [@kullberg2024]). Beyond these,
-early implementations of advanced methods, such as causal mediation
-analysis tailored to microbiome multi-omics data, have been implemented for
-SE [@jiang2025], highlighting its readiness to support the adoption of
-constantly developing methodology.
-
-**Function- and sequence-level analyses.** Taxonomic analysis is
-frequently complemented by functional analyses, either based on
-functional predictions derived from amplicon or metagenomic
-sequences, or from parallel metabolomic, metatranscriptomic or other functional
-assays. Our framework not only supports the incorporation of functional
-abundance tables within the same data objects, but many statistical methods implemented in the ecosystem are generic and can therefore be applied across
-different omics data types. Where appropriate, specialized methods are also
-available; for instance, regarding metabolome
-analyses, the notame package [@klavus2020] has recently added SE support,
-and the R4MS project provides many interoperable tools [@gatto2025].
-The framework has found recent applications in extended analyses of metagenomic
-features, for instance, antimicrobial resistome composition [@salehi2025].
-We have also converted a large-scale compilation of resistome profiles in 8,972
-metagenome samples [@lee2023] into the TreeSE format to support
-research and training activities in this area of microbiome analysis.
-
-**Spatio-temporal, ecological, and epidemiological models.** Microbiome time
-series [@berg2020] encompass a wide range of study designs, ranging
-from short to long follow-up times, sparse to dense data, univariate
-to multivariate and multi-omic monitoring [@velten2022], and real,
-pseudo, or simulated time series. Moreover, an increasing number of
-studies incorporate spatial dimension in microbiome analysis [@ruuskanen2021].
-While spatio-temporal analyses require specialized methods, the miaTime R
-package offers a set of data wrangling methods to support longitudinal,
-multi-modal microbiome analysis. In addition, Bioconductor contains applicable
-methods from other research domains, namely single-cell omics
-[@amezquita2020] and spatial transcriptomics [@crowell2025], which use closely
-related data containers. Spatial and temporal information can be
-incorporated as a covariate (*e.g.*, location or time) or by estimating
-temporally or spatially resolved metrics, such as divergence (dissimilarity
-between consecutive time points), autocorrelation (similarity of closely
-related samples), and feature modality (whether a feature exhibits multiple
-abundance states). Another type of temporal analysis
-includes the time-to-event, or survival models, which are encountered
-regularly in epidemiological and population cohort studies; for microbiome
-data, these analyses require specialized approaches, as proposed in previous
-studies [@salosensaari2021; @calle2023]. We also provide methods to simulate
-time series from standard models of microbial community dynamics including
-Hubbell's neutral model, generalized Lotka-Volterra, and the
-consumer-resource model through the miaSim package [@gao2023]. Our framework
-provides a robust basis for developing extended methods for longitudinal
-multi-omics, which is currently an active area of investigation [@sherwani2025].
-
-**Multi-modal integration.** A key benefit of the ecosystem lies in its ability
-to support the integration of microbial abundance data with other omics
-modalities, such as resistomes [@salehi2025], metabolomes [@hintikka2021],
-host genomes [@qin2022], transcriptomes, or proteomes
-[@nyholm2020; @moreno-indias2021] (@fig-downstream_analyses). As we have
-demonstrated, the integrative data containers support complex combinations of
-omics datasets [@huber2015; @ramos2017; @amezquita2020]. By leveraging
-standardized multi-assay data structures, users can apply a growing
-number of integrative methods for multi-omics analysis. This eliminates the
-need for manual data wrangling, reduces the risk of errors (*e.g.*, sample
-mismatches), and enables the creation of modular, efficient, and reproducible
-workflows. Such integrative approaches in microbiome
-research can be broadly categorized into three groups: Machine Learning (ML)
-prediction, association-based approaches, and
-latent variable modeling [@jeganathan2021; @sherwani2025;
-@moreno-indias2021; @mallick2024; @bastiaanssen2023;
-@argelaguet2020; @singh2019; @mangnier2025].
-ML approaches aim to integrate multiple omics modalities into a
-single predictive model. However, naive concatenation of feature tables can
-obscure modality-specific signals and reduce predictive performance. Methods
-such as IntegratedLearner [@mallick2024] address this limitation by modeling
-each modality separately while leveraging their complementary predictive
-information within a unified framework.
-Association-based methods aim to quantify relationships between datasets.
-Whereas the cross-correlation analysis can be used to capture direct
-associations of samples or features between two datasets, anansi can supervise
-such analyses  by incorporating known functional relations. While these
-association-based approaches are often easier to interpret, they do not
-explicitly account for the fact that microbes operate within complex
-communities. In contrast, latent variable methods such
-as multi-omics factor analysis [@argelaguet2020],
-joint robust PCA [@martino2019] and multiblock partial least
-squares discriminant analysis [@singh2019] model shared latent
-structure across modalities, enabling the discovery and visualization of
-coordinated variation at the community level.
-The available methodologies are rapidly increasing, and we aim to
-accelerate the development, benchmarking, and standardization of
-multi-modal extensions for microbiome analysis through a systematic integrative
-framework proposed here.
-
-**Other methods and programming environments.** Several other methods have
-been employed in microbiome data science. Examples include network analysis
-[@peschel2021], ML-based prediction and classification [@topcuoglu2021], and
-microbe-set enrichment
-analysis [@kou2020; @pham2025]. The recent adoption of interoperable
-data containers and shared methodological approaches in related research fields
-can significantly expand the transfer of existing toolkits to adjacent or emerging
-disciplines. Importantly, this framework enables integration not only within the Bioconductor ecosystem
-but also with external pipelines, including bioBakery [@navarro2024; @mciver2017], and foreign platforms through language-specific interfaces,
-namely `Rcpp` for C+, `reticulate` for Python, and `JuliaCall` for Julia.
-These connections allow users to combine the
-most suitable tools across multiple frameworks, while ensuring
-cross-language interoperability of structured data through standard containers such as TreeSE and MAE.
-
-```{r}
-#| label: downstream_analyses
-#| eval: false
-#| echo: false
-#| message: false
-
-# Load packages
-pkgs <- c("maaslin3", "mia", "miaTime", "microbiomeDataSets")
-temp <- sapply(pkgs, function(x) {
-    suppressMessages(require(x, character.only = TRUE))
-})
-
-# Load data
-tse <- SprockettTHData()
-# Subset by taking only fecal samples from infants
-tse <- tse[, tse[["Sample_Type"]] %in% c("Feces")]
-tse <- tse[, tse[["Age_Class"]] %in% c("Infant")]
-
-# Agglomerate and apply transformations
-tse <- agglomerateByRanks(tse)
-tse <- transformAssay(tse, method = "relabundance", altexp = altExpNames(tse))
-tse <- transformAssay(
-    tse,
-    method = "clr", pseudocount = TRUE, altexp = altExpNames(tse)
-)
-altExp(tse, "prev_genus") <- subsetByPrevalent(
-    altExp(tse, "Genus"),
-    prevalence = 0.5, detection = 0.001
-)
-rownames(altExp(tse, "prev_genus")) <- gsub(
-    "/| ", "_", rownames(altExp(tse, "prev_genus"))
-)
-
-# Calculate alpha diversity
-tse <- addAlpha(tse, index = "faith")
-
-# Perform PCoA
-tse <- addMDS(tse, assay.type = "counts", method = "unifrac", niter = 10L)
-
-# Perform dbRDA
-tse <- addRDA(
-    tse,
-    assay.type = "clr", method = "euclidean",
-    formula = x ~ Age_Months + Country, na.action = na.exclude
-)
-# Remove the RDA object as it takes a lot of space
-attr(reducedDim(tse, "RDA"), "obj") <- NULL
-
-# Perform DAA
-res_full <- maaslin3(
-    input_data = altExp(tse, "prev_genus"),
-    output = "DAA_example",
-    formula = "~ Age_Months + Sex + Country",
-    normalization = "TSS",
-    transform = "LOG",
-    verbosity = "ERROR"
-)
-res <- res_full[["fit_data_abundance"]][["results"]]
-res <- res[res[["value"]] == "Age_Months", ]
-signif_feat <- res[
-    !is.na(res[["qval_individual"]]) & res[["qval_individual"]] < 0.05,
-    "feature"
-]
-rowData(altExp(tse, "prev_genus"))[["signif"]] <- rownames(
-    altExp(tse, "prev_genus")
-) %in% signif_feat
-
-# Calculate time divergence
-tse <- addStepwiseDivergence(
-    tse,
-    time.col = "Age_Months",
-    group = "Subject_ID", method = "bray",
-    tree = rowTree(tse)
-)
-
-# Save object so that it can be used in visualization step without running the
-# analyses
-saveRDS(tse, file.path("data", "tse.rds"))
-```
-
-```{r}
-#| label: fig-downstream_analyses
-#| echo: false
-#| message: false
-#| warning: false
-#| fig-cap: "Common visualization methods applied to time series data on infants
-#|   from three different countries (Finland, Bangladesh, and Bolivia) based on
-#|   public datasets - SprockettTHData()
-#|   [@sprockett2020; @subramanian2014; @vatanen2016] available via
-#|   microbiomeDataSets [@microbiomedatasets]. **a**, Phylogenetic
-#|   relationships. **b**, Phyla abundances of the samples ordered by age,
-#|   stratified by country and gender. Actinobacteria is more abundant in
-#|   Bolivia and Bangladesh compared to Finland.  **c&ndash;d**,
-#|   Multidimensional Scaling (MDS) using UniFrac distances and distance-based
-#|   Redundancy Analysis (dbRDA) based on Aitchison distance, respectively. Both
-#|   ordination methods shows clear pattern separating microbial profiles in
-#|   different countries. dbRDA shows an additional association between
-#|   microbial profile and age. **e&ndash;f**, Faith's phylogenetic diversity by
-#|   country and age respectively. **g**, Differential Abundance Analysis (DAA)
-#|   results. Two genera exhibit an association with age. **h**, UniFrac
-#|   divergence between consecutive time points. Results indicate slow
-#|   stabilization of microbial communities."
-#| fig-width: 19
-#| fig-height: 10
-
-# Load packages
-pkgs <- c("miaViz", "patchwork", "scater")
-temp <- sapply(pkgs, function(x) {
-    suppressMessages(require(x, character.only = TRUE))
-})
-
-# Load data
-file_path <- file.path("data", "tse.rds")
-if (!file.exists(file_path)) {
-    stop("Run manually the chunk above. '", file_path, "' cannot found.")
-}
-tse <- readRDS(file_path)
-
-# Get phylum names
-phylum_names <- sort(unique(rowData(altExp(tse, "Phylum"))[, "Phylum"]))
-# Named vector of phylum colors
-phylum_colors <- setNames(
-    scater:::.get_palette("tableau20")[seq_along(phylum_names)],
-    phylum_names
-)
-
-# Define a font size
-title_size <- 16
-text_size <- 12
-
-# Visualize phylogeny
-p_tree <- plotRowTree(
-    altExp(tse, "Family"),
-    edge.colour.by = "Phylum", layout = "ape"
-) +
-    scale_color_manual(values = phylum_colors) + # Manually set colors
-    guides(color = "none")
-
-# Visualize abundances with barplot
-p_bar <- plotAbundance(
-    altExp(tse, "Phylum"),
-    assay.type = "relabundance",
-    col.var = c("Country", "Sex"), facet.cols = TRUE, scales = "free",
-    order.col.by = "Age_Months"
-) +
-    guides(fill = guide_legend(title = "Phylum")) +
-    scale_color_manual(values = phylum_colors) +
-    theme(
-        axis.title.y = element_text(size = title_size),
-        axis.text.y = element_text(size = text_size)
-    )
-
-# Visualize alpha diversity
-p_alpha <- plotColData(
-    tse,
-    y = "faith", x = "Country", colour_by = "Country",
-    show_boxplot = TRUE, show_violin = FALSE, point_alpha = 0.2
-) +
-    labs(y = "Faith", x = "Country") +
-    theme(
-        legend.position = "none",
-        axis.title.x = element_text(size = title_size),
-        axis.title.y = element_text(size = title_size),
-        axis.text.x = element_text(size = text_size, angle = 20, hjust = 0.6, vjust = 0.8),
-        axis.text.y = element_text(size = text_size)
-    )
-
-p_alpha2 <- plotColData(
-    tse,
-    y = "faith", x = "Age_Months"
-) +
-    geom_smooth(method = "lm") +
-    labs(y = "Faith", x = "Age in months") +
-    theme(
-        axis.title.x = element_text(size = title_size),
-        axis.title.y = element_text(size = title_size),
-        axis.text.x = element_text(size = text_size),
-        axis.text.y = element_text(size = text_size)
-    )
-
-# Visualize PCoA
-p_mds <- plotMDS(tse, colour_by = "Country") +
-    theme(
-        legend.position = "inside",
-        legend.justification = c("right", "top"),
-        axis.title.x = element_text(size = title_size),
-        axis.title.y = element_text(size = title_size),
-        axis.text.x = element_text(size = text_size),
-        axis.text.y = element_text(size = text_size),
-        legend.title = element_text(size = title_size),
-        legend.text = element_text(size = text_size)
-      )
-
-# Visualize dbRDA
-p_rda <- plotRDA(tse, "RDA", colour.by = "Country", add.significance = FALSE) +
-    theme(
-        legend.position = "none",
-        axis.title.x = element_text(size = title_size),
-        axis.title.y = element_text(size = title_size),
-        axis.text.x = element_text(size = text_size),
-        axis.text.y = element_text(size = text_size)
-    )
-
-# Visualize abundances vs age
-p_daa <- plotExpression(
-    altExp(tse, "prev_genus"),
-    features = rownames(altExp(tse, "prev_genus"))[rowData(altExp(tse, "prev_genus"))[["signif"]]],
-    assay.type = "relabundance", x = "Age_Months", ncol = 3L,
-) +
-    scale_y_log10() +
-    geom_smooth() +
-    labs(x = "Age in months", y = "Relative abundance") +
-    theme(
-        axis.title.x = element_text(size = title_size),
-        axis.title.y = element_text(size = title_size),
-        axis.text.x = element_text(size = text_size),
-        axis.text.y = element_text(size = text_size)
-    )
-
-# Visualize divergence
-tse_sub <- tse[, !is.na(tse[["time_diff"]]) & tse[["time_diff"]] >= 0.8 & tse[["time_diff"]] <= 1.2]
-p_divergence <- plotColData(tse_sub, y = "divergence", x = "Age_Months") +
-    geom_smooth(method = "lm") +
-    labs(x = "Age in months", y = expression(Delta ~ "UniFrac" ~ "(N, N-1)")) +
-    theme(
-        legend.position = "none",
-        axis.title.x = element_text(size = title_size),
-        axis.title.y = element_text(size = title_size),
-        axis.text.x = element_text(size = text_size),
-        axis.text.y = element_text(size = text_size)
-    )
-
-# Combine plots
-p1 <- (p_tree / p_bar) +
-    plot_layout(guides = "collect")
-p2 <- (p_mds / p_rda) +
-    plot_layout(heights = c(1, 1))
-p3 <- ((p_alpha | p_alpha2) / p_daa / p_divergence) +
-    plot_layout(heights = c(1, 1, 1))
-p <- (p1 | p2 | p3) +
-    plot_layout(widths = c(0.33, 0.4, 0.32)) +
-    plot_annotation(tag_levels = "a") &
-    theme(plot.tag = element_text(size = 22, face = "bold"))
-p
-```
-
-# Accessible analysis and community {#sec-community}
-
-Modern science is embodied by a critical community capable of
-assessing discoveries and replicating results [@wootton2016].
-Open source developer communities present a timely manifestation of this
-principle, with technical, legal, sociological and epistemic consequences
-[@hocquet2024]. FAIR principles for software support inclusive
-access to well-documented and user-friendly methods [@barker2022],
-and are facilitated by the extensive quality control and
-documentation standards of Bioconductor [@huber2015].
-In addition to these technical
-demands, the development and quality control of research software
-significantly relies on a strong community engagement, which
-stimulates continuous software improvement and promotes the emergence and
-dissemination of evidence-based best practices [@berg2020;
-@barker2022; @hocquet2024]. We recommend starting with simple
-methods [@pelto2025], calculating derived quantities such
-as diversity, prevalence, and other such measures early in
-the workflow, and complementing analyses with visual exploration. These
-practices can improve the transparency and interpretability of the
-analysis and its results. Expressive code and meaningful comments support
-reproducibility and verification.
-
-Harmonized data structures and access to validated methods support standardized
-and transparent data wrangling across studies while facilitating method sharing,
-benchmarking, and reproducible comparisons. These capabilities help establish
-community best practices and build consensus while allowing users to flexibly
-select and evaluate methods appropriate for their specific data and research
-questions. The Bioconductor framework naturally aligns with these goals through
-its open ecosystem of data resources, interoperable software, and educational
-materials. Community building is actively supported through online training
-resources and communication channels, making it easier for both developers and
-users to contribute to the continued development and standardization of the
-ecosystem. Together with interactive applications, these resources offer
-accessible entry points for developers and users, regardless of their
-programming experience.
-
-**The OMA book.** _Orchestrating Microbiome Analysis with Bioconductor_ (OMA)
-is an online book published at [https://bioconductor.org/books/release/OMA](https://bioconductor.org/books/release/OMA)
-that provides a comprehensive guide to the (Tree)SE framework for microbiome
-data science in Bioconductor, including practical guidelines,
-reproducible workflows, and training material for integrative microbiome
-analyses. The book is versioned according to Bioconductor's biannual software
-release cycles. The work incorporates rich feedback from the user community and
-microbiome training courses. The OMA book aligns to a broader Bioconductor convention, where
-prominent data structures [@huber2015; @ramos2017; @huang2021]
-designed for multi-table data integration have been described across several
-domains, such as single-cell omics
-(OSCA book [@amezquita2020]) and spatial transciptomics (OSTA book [@crowell2025]).
-These resources
-demonstrate how standard data containers can support statistical
-programming on interlinked multi-table datasets.
-
-**Interactive applications.** Graphical user interfaces provide
-accessible entry points to the framework. The iSEEtree and miaDash
-packages provide interactive analysis and visualization tools for
-microbiome data [@benedetti2025]. The former extends iSEE to provide support for
-TreeSE objects, while the latter builds on iSEEtree to enable analyses without
-requiring any programming. Their interface supports automatic generation of
-source code and replicable workflows as well as analysis templates for users
-without a strong programming expertise. Moreover, the tidy R paradigm, available
-through tidyomics, simplifies the syntax and streamlines analytical
-workflows [@hutchison2024]. These tools allow users to analyze and
-visualize complex data combinations with ease.
-
-**Community.** Its widespread adoption has made R one of the most cited software
-resources of our time [@pearson2025] and the introduction of the
-shared data structures facilitates the broad interoperability of the
-methods ecosystem. Bioconductor has a strong tradition in fostering the
-R user community through shared data structures and training activities
-[@drnevich2025]. An active community of developers and users thrives online,
-supporting the software sustainability and promoting good practices in
-scientific computing [@wilson2017]. The community interacts via several online
-communication channels, including Bioconductor Zulip, GitHub platform,
-and an email list. The development of the framework is influenced by
-feedback from the user community through these channels, regular
-meetings, and training workshops.
-
 # Outlook {#sec-discussion}
 
 ```{r}
@@ -1717,6 +1716,8 @@ we have introduced a comprehensive, interoperable ecosystem
 developed as an extensive community effort. We also provide exhaustive guidance in
 the OMA book, thereby supporting independent learning and reproducible analysis in
 microbiome research and beyond.
+
+
 
 **The Bioconductor community** is widely recognized for
 developing open research software for life sciences. Its


### PR DESCRIPTION
Hi!

Starting from the minor changes, this PR solves issues https://github.com/microbiome/OMAManuscript/issues/106, https://github.com/microbiome/OMAManuscript/issues/105, https://github.com/microbiome/OMAManuscript/issues/103 and https://github.com/microbiome/OMAManuscript/issues/107.

For the bigger changes, I combined the benchmark with the section on "Alternative frameworks" and moved this combined section to the end. This helps keep the focus in the main body on the TreeSE framework. Then, at the end, the "Alternative frameworks" section will discuss other frameworks and compare them to TreeSE backed by the benchmark results (figure also moved to this section). **I still need to improve/rewrite the text for this section** as discussed in https://github.com/microbiome/OMAManuscript/issues/102.


This PR also works towards https://github.com/microbiome/OMAManuscript/issues/101 in that Table 1 is put together with Figure 2, but I think Figure 2 (TreeSE and MAE data containers) should be restructured a bit to integrate also the information from Table 1 (let's discuss further in https://github.com/microbiome/OMAManuscript/issues/101).